### PR TITLE
[DowngradePhp54] Enable skipped test on DowngradeBinaryNotationRectorTest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "phpunit/phpunit": "^9.5",
         "rector/phpstan-rules": "^0.6",
         "rector/rector-debugging": "dev-main",
-        "rector/rector-src": "dev-main#12f2056",
+        "rector/rector-src": "dev-main",
         "symplify/easy-ci": "^11.1",
         "symplify/easy-coding-standard": "^11.1",
         "symplify/phpstan-extensions": "^11.1",

--- a/rules-tests/DowngradePhp54/Rector/LNumber/DowngradeBinaryNotationRector/DowngradeBinaryNotationRectorTest.php
+++ b/rules-tests/DowngradePhp54/Rector/LNumber/DowngradeBinaryNotationRector/DowngradeBinaryNotationRectorTest.php
@@ -14,8 +14,6 @@ final class DowngradeBinaryNotationRectorTest extends AbstractRectorTestCase
      */
     public function test(string $filePath): void
     {
-        $this->markTestSkipped('This requires more than reprint, exact value is needed');
-
         $this->doTestFile($filePath);
     }
 

--- a/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -73,7 +73,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $rawValueWithoutUnderscores = str_replace('_', '', $rawValue);
+        $rawValueWithoutUnderscores = str_replace('_', '', (string) $rawValue);
         $node->setAttribute(AttributeKey::RAW_VALUE, $rawValueWithoutUnderscores);
 
         $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);


### PR DESCRIPTION
I tried locally and it seems test is working so it should be enabled.