### PR TITLE
Back to require-dev rector/rector-src:dev-main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "phpunit/phpunit": "^9.5",
         "rector/phpstan-rules": "^0.6",
         "rector/rector-debugging": "dev-main",
-        "rector/rector-src": "dev-main#377713ae7044739b33a2186bbebbd253f7a0efdd",
+        "rector/rector-src": "dev-main",
         "symplify/easy-ci": "^11.1",
         "symplify/easy-coding-standard": "^11.1",
         "symplify/phpstan-extensions": "^11.1",


### PR DESCRIPTION
This was temporary using : 

```
"rector/rector-src": "dev-main#377713ae7044739b33a2186bbebbd253f7a0efdd",
```

For PR:

- https://github.com/rectorphp/rector-downgrade-php/pull/28

Since that merged and verified in rector-src, it can back to use dev-main again.