### PR TITLE
[Downgrade PHP 7.4] Add return throw to ArrowFunctionToAnonymousFunctionRectorL

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,6 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::NAMING,
         SetList::TYPE_DECLARATION,
         SetList::EARLY_RETURN,
-        SetList::TYPE_DECLARATION_STRICT,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
         SetList::CODING_STYLE,
     ]);

--- a/rules-tests/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector/Fixture/arrow_function_with_throw.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector/Fixture/arrow_function_with_throw.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector\Fixture;
+
+final class ArrowFunctionWithThrow
+{
+    public function run()
+    {
+        return fn () => throw new \LogicException('Lazy proxy has no initializer.');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector\Fixture;
+
+final class ArrowFunctionWithThrow
+{
+    public function run()
+    {
+        return function () {
+            throw new \LogicException('Lazy proxy has no initializer.');
+        };
+    }
+}
+
+?>

--- a/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
+++ b/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\Throw_;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Php72\NodeFactory\AnonymousFunctionFactory;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -71,6 +72,29 @@ CODE_SAMPLE
     {
         $stmts = [new Return_($node->expr)];
 
-        return $this->anonymousFunctionFactory->create($node->params, $stmts, $node->returnType, $node->static);
+        $anonymousFunctionFactory = $this->anonymousFunctionFactory->create(
+            $node->params,
+            $stmts,
+            $node->returnType,
+            $node->static
+        );
+
+        // downgrade "return throw"
+        $this->traverseNodesWithCallable($anonymousFunctionFactory, static function (Node $node): ?Throw_ {
+            if (! $node instanceof Return_) {
+                return null;
+            }
+
+            if (! $node->expr instanceof Node\Expr\Throw_) {
+                return null;
+            }
+
+            $throw = $node->expr;
+
+            // throw expr to throw stmts
+            return new Throw_($throw->expr);
+        });
+
+        return $anonymousFunctionFactory;
     }
 }


### PR DESCRIPTION
Just to make this rule work on its own :+1: 