### PR TITLE
Fix direct foreach destruction to list

### DIFF
--- a/rules/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector.php
+++ b/rules/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp71\Rector\Array_;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Name;
+use PhpParser\Node\Expr\List_;
 use PhpParser\Node\Stmt\Foreach_;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -66,13 +63,8 @@ CODE_SAMPLE
         return null;
     }
 
-    private function processToList(Array_ $array): FuncCall
+    private function processToList(Array_ $array): List_
     {
-        $args = [];
-        foreach ($array->items as $arrayItem) {
-            $args[] = $arrayItem instanceof ArrayItem ? new Arg($arrayItem->value) : null;
-        }
-
-        return new FuncCall(new Name('list'), $args);
+        return new List_($array->items);
     }
 }

--- a/tests/Issues/DowngradeForeachDestruction/DowngradeForeachDestructionTest.php
+++ b/tests/Issues/DowngradeForeachDestruction/DowngradeForeachDestructionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\DowngradeForeachDestruction;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeForeachDestructionTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<array<string>>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DowngradeForeachDestruction/Fixture/foreach-destruction.php.inc
+++ b/tests/Issues/DowngradeForeachDestruction/Fixture/foreach-destruction.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+foreach (array(array(1, 2)) as [$a, $b]) {
+    echo "$a $b";
+}
+
+?>
+-----
+<?php
+
+foreach (array(array(1, 2)) as $arrayItem) {
+    list($a, $b) = $arrayItem;
+    echo "$a $b";
+}
+
+?>

--- a/tests/Issues/DowngradeForeachDestruction/config/configured_rule.php
+++ b/tests/Issues/DowngradeForeachDestruction/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp55\Rector\Foreach_\DowngradeForeachListRector;
+use Rector\DowngradePhp71\Rector\Array_\SymmetricArrayDestructuringToListRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
+    $rectorConfig->rule(SymmetricArrayDestructuringToListRector::class);
+    $rectorConfig->rule(DowngradeForeachListRector::class);
+};


### PR DESCRIPTION
```php
foreach (array(array(1, 2)) as [$a, $b]) {
}
# should downgrade to php 5.4 as
foreach (array(array(1, 2)) as $arrayItem) {
    list($a, $b) = $arrayItem;
}
```
This needs 2 runs right now:

https://getrector.org/demo/2aeb29e6-477c-4c6a-8011-abdf5f793793
https://getrector.org/demo/8eddef03-5d6b-484f-b323-817f69d7cfb0

Test added in `tests/Issues` like in rector-src.