### PR TITLE
Downgrade Jetbrains\PhpStorm\Language via DowngradeAttributeToAnnotationRector

### DIFF
--- a/config/set/downgrade-php80.php
+++ b/config/set/downgrade-php80.php
@@ -54,6 +54,8 @@ return static function (RectorConfig $rectorConfig): void {
             new DowngradeAttributeToAnnotation('Symfony\Contracts\Service\Attribute\Required', 'required'),
             // Nette
             new DowngradeAttributeToAnnotation('Nette\DI\Attributes\Inject', 'inject'),
+            // Jetbrains\PhpStorm\Language under nette/utils
+            new DowngradeAttributeToAnnotation('Jetbrains\PhpStorm\Language', 'language'),
         ]);
 
     $rectorConfig->rule(DowngradeDereferenceableOperationRector::class);


### PR DESCRIPTION
@TomasVotruba this is to resolve downgrade build on rector-src:

Downgrade build failure seems unrelated:

```diff
------------------------------------------------------------
Parse error: rector-prefixed-downgraded/vendor/nette/utils/src/Utils/Arrays.php:171
    169|      */
    170|     public static function grep(array $array, #[\JetBrains\PhpStorm\Language('RegExp')] string $pattern, int $flags = 0) : array
  > 171|     {
    172|         return Strings::pcre('preg_grep', [$pattern, $array, $flags]);
    173|     }
Unexpected '{', expecting variable (T_VARIABLE) in rector-prefixed-downgraded/vendor/nette/utils/src/Utils/Arrays.php on line 171
------------------------------------------------------------
Parse error: rector-prefixed-downgraded/vendor/nette/utils/src/Utils/Strings.php:399
    397|      */
    398|     public static function split(string $subject, #[\JetBrains\PhpStorm\Language('RegExp')] string $pattern, int $flags = 0) : array
  > 399|     {
    400|         return self::pcre('preg_split', [$pattern, $subject, -1, $flags | \PREG_SPLIT_DELIM_CAPTURE]);
    401|     }
Unexpected '{', expecting variable (T_VARIABLE) in rector-prefixed-downgraded/vendor/nette/utils/src/Utils/Strings.php on line 399
```

seems due to new nette/utils release https://github.com/nette/utils/releases/tag/v3.2.9

see https://github.com/rectorphp/rector-src/actions/runs/3948109106/jobs/6757715096#step:14:71

I don't know if there is `@language` Annotation, but I think it can be solution for downgrading nette/utils.