### PR TITLE
Downgrade trailing commas in unset()

### DIFF
--- a/config/set/downgrade-php73.php
+++ b/config/set/downgrade-php73.php
@@ -11,6 +11,7 @@ use Rector\DowngradePhp73\Rector\FuncCall\DowngradeTrailingCommasInFunctionCalls
 use Rector\DowngradePhp73\Rector\FuncCall\SetCookieOptionsArrayToArgumentsRector;
 use Rector\DowngradePhp73\Rector\List_\DowngradeListReferenceAssignmentRector;
 use Rector\DowngradePhp73\Rector\String_\DowngradeFlexibleHeredocSyntaxRector;
+use Rector\DowngradePhp73\Rector\Unset_\DowngradeTrailingCommasInUnsetRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(PhpVersion::PHP_72);
@@ -21,4 +22,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(SetCookieOptionsArrayToArgumentsRector::class);
     $rectorConfig->rule(DowngradeIsCountableRector::class);
     $rectorConfig->rule(DowngradePhp73JsonConstRector::class);
+    $rectorConfig->rule(DowngradeTrailingCommasInUnsetRector::class);
 };

--- a/rules-tests/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector/DowngradeTrailingCommasInUnsetRectorTest.php
+++ b/rules-tests/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector/DowngradeTrailingCommasInUnsetRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp73\Rector\Unset_\DowngradeTrailingCommasInUnsetRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeTrailingCommasInUnsetRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector/Fixture/fixture.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\Unset_\DowngradeTrailingCommasInUnsetRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $a = '';
+        unset($a, $b,);
+        unset(
+            $c,
+            $d,
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\Unset_\DowngradeTrailingCommasInUnsetRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        $a = '';
+        unset($a, $b);
+        unset($c, $d);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp73\Rector\Unset_\DowngradeTrailingCommasInUnsetRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/config.php');
+    $rectorConfig->rule(DowngradeTrailingCommasInUnsetRector::class);
+};

--- a/rules/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector.php
+++ b/rules/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp73\Rector\Unset_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Unset_;
+use Rector\Core\Rector\AbstractRector;
+use Rector\DowngradePhp73\Tokenizer\FollowedByCommaAnalyzer;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Tests\DowngradePhp73\Rector\Unset_\DowngradeTrailingCommasInUnsetRector\DowngradeTrailingCommasInUnsetRectorTest
+ */
+final class DowngradeTrailingCommasInUnsetRector extends AbstractRector
+{
+    public function __construct(
+        private readonly FollowedByCommaAnalyzer $followedByCommaAnalyzer
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove trailing commas in unset',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+unset(
+	$x,
+	$y,
+);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+unset(
+	$x,
+	$y
+);
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Unset_::class];
+    }
+
+    /**
+     * @param Unset_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->vars !== []) {
+            $lastArgumentPosition = array_key_last($node->vars);
+
+            $last = $node->vars[$lastArgumentPosition];
+            if (! $this->followedByCommaAnalyzer->isFollowed($this->file, $last)) {
+                return null;
+            }
+
+            // remove comma
+            $last->setAttribute(AttributeKey::FUNC_ARGS_TRAILING_COMMA, false);
+            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+
+            return $node;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
```php
unset($a, $b,);
# to
unset($a, $b);
```

https://3v4l.org/vS0VI

Pretty much like [DowngradeTrailingCommasInFunctionCallsRector](https://github.com/rectorphp/rector-downgrade-php/blob/main/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php) but `Unset_` has `->values` instead of `->args`. Both cases could be handled in a single rector.