### PR TITLE
Fix closing identifier constraints for flexible here doc rector

### DIFF
--- a/rules-tests/DowngradePhp73/Rector/String_/DowngradeFlexibleHeredocSyntaxRector/Fixture/line_ends_with_newline_or_semicolon.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/String_/DowngradeFlexibleHeredocSyntaxRector/Fixture/line_ends_with_newline_or_semicolon.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\String_\DowngradeFlexibleHeredocSyntaxRector\Fixture;
+
+class LineEndsWithNewlineOrSemicolon
+{
+    public function run()
+    {
+        $good1 = <<<EOS
+test
+EOS;
+
+        $good2 = <<<EOS
+test
+EOS
+;
+
+        $needsDowngrade1 = sprintf(<<<EOS
+test %s
+EOS, 'more');
+
+        $needsDowngrade2 = <<<EOS
+test
+EOS; $z = '';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\String_\DowngradeFlexibleHeredocSyntaxRector\Fixture;
+
+class LineEndsWithNewlineOrSemicolon
+{
+    public function run()
+    {
+        $good1 = <<<EOS
+test
+EOS;
+
+        $good2 = <<<EOS
+test
+EOS
+;
+
+        $needsDowngrade1 = sprintf(<<<EOS
+test %s
+EOS
+, 'more');
+
+        $needsDowngrade2 = <<<EOS
+test
+EOS
+; $z = '';
+    }
+}
+
+?>

--- a/rules/DowngradePhp73/Rector/String_/DowngradeFlexibleHeredocSyntaxRector.php
+++ b/rules/DowngradePhp73/Rector/String_/DowngradeFlexibleHeredocSyntaxRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\String_;
 use Rector\Core\Rector\AbstractRector;
+use Rector\DowngradePhp73\Tokenizer\FollowedByNewlineOnlyMaybeWithSemicolonAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -21,6 +22,11 @@ final class DowngradeFlexibleHeredocSyntaxRector extends AbstractRector
      * @var int[]
      */
     private const HERENOW_DOC_KINDS = [String_::KIND_HEREDOC, String_::KIND_NOWDOC];
+
+    public function __construct(
+        private readonly FollowedByNewlineOnlyMaybeWithSemicolonAnalyzer $followedByNewlineOnlyMaybeWithSemicolonAnalyzer
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -68,7 +74,9 @@ CODE_SAMPLE
 
         // skip correctly indented
         $docIndentation = (string) $node->getAttribute(AttributeKey::DOC_INDENTATION);
-        if ($docIndentation === '') {
+        if ($docIndentation === '' &&
+            $this->followedByNewlineOnlyMaybeWithSemicolonAnalyzer->isFollowed($this->file, $node)
+        ) {
             return null;
         }
 

--- a/rules/DowngradePhp73/Tokenizer/FollowedByNewlineOnlyMaybeWithSemicolonAnalyzer.php
+++ b/rules/DowngradePhp73/Tokenizer/FollowedByNewlineOnlyMaybeWithSemicolonAnalyzer.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp73\Tokenizer;
+
+use PhpParser\Node;
+use Rector\Core\ValueObject\Application\File;
+
+final class FollowedByNewlineOnlyMaybeWithSemicolonAnalyzer
+{
+    public function isFollowed(File $file, Node $node): bool
+    {
+        $oldTokens = $file->getOldTokens();
+
+        $nextTokenPosition = $node->getEndTokenPos() + 1;
+
+        if (isset($oldTokens[$nextTokenPosition]) && $oldTokens[$nextTokenPosition] === ';') {
+            ++$nextTokenPosition;
+        }
+
+        return ! isset($oldTokens[$nextTokenPosition]) ||
+            isset($oldTokens[$nextTokenPosition][1]) &&
+            \str_starts_with((string) $oldTokens[$nextTokenPosition][1], "\n");
+    }
+}


### PR DESCRIPTION
> Prior to PHP 7.3.0, it is very important to note that the line with the closing identifier must contain no other characters, except a semicolon (;).

[PHP manual](https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc)

This works if an indented here/nowdoc is rewritten but not if the source isn't indented.

```php
$needsDowngrade2 = <<<EOS
test
EOS; $z = '';
```

https://getrector.com/demo/14c60416-0504-4b64-ab8b-f7f861892e67 vs. https://getrector.com/demo/06cb930b-d7a5-4e90-9e6d-76a69fad015d