### PR TITLE
[DowngradePhp74] Skip same return type on DowngradeCovariantReturnTypeRector

### DIFF
--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Fixture/skip_same_return_type.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Fixture/skip_same_return_type.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Fixture;
+
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source\Handler;
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source\ResponseInterface;
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source\TempResponse;
+
+/**
+ * @extends Handler<TempResponse>
+ */
+final class SkipSameReturnType extends Handler
+{
+    protected function set(): ResponseInterface {
+        return new TempResponse();
+    }
+}

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Fixture/sub_return_type.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Fixture/sub_return_type.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Fixture;
+
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source\Handler;
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source\TempResponse;
+
+/**
+ * @extends Handler<TempResponse>
+ */
+final class SubReturnType extends Handler
+{
+    protected function set(): TempResponse {
+        return new TempResponse();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Fixture;
+
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source\Handler;
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source\TempResponse;
+
+/**
+ * @extends Handler<TempResponse>
+ */
+final class SubReturnType extends Handler
+{
+    protected function set(): \Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source\ResponseInterface {
+        return new TempResponse();
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Source/Handler.php
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Source/Handler.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source;
+
+/**
+ * @template T of ResponseInterface
+ */
+abstract class Handler
+{
+    /**
+     * @return T
+     */
+    abstract protected function set(): ResponseInterface;
+}

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Source/ResponseInterface.php
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Source/ResponseInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source;
+
+interface ResponseInterface
+{
+}

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Source/TempResponse.php
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Source/TempResponse.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source;
+
+class TempResponse implements ResponseInterface
+{
+}

--- a/rules/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
+++ b/rules/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
@@ -214,7 +214,7 @@ CODE_SAMPLE
             /** @var Type $parentReturnType */
             $parentReturnType = $this->privatesAccessor->callPrivateMethod(
                 $parameterMethodReflection,
-                'getReturnType',
+                'getNativeReturnType',
                 []
             );
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7768