### PR TITLE
[DowngradePhp74] Skip nullable parent on DowngradeCovariantReturnTypeRector

### DIFF
--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Fixture/skip_return_non_nullable_override_nullable.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Fixture/skip_return_non_nullable_override_nullable.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Fixture;
+
+use Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source\ReturnNullable;
+
+final class SkipReturnNonNullableOverrideNullable implements ReturnNullable
+{
+    public function run(): array
+    {
+        return ['test'];
+    }
+}

--- a/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Source/ReturnNullable.php
+++ b/rules-tests/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector/Source/ReturnNullable.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp74\Rector\ClassMethod\DowngradeCovariantReturnTypeRector\Source;
+
+interface ReturnNullable
+{
+    public function run(): ?array;
+}


### PR DESCRIPTION
@TomasVotruba @defunctl  continue of PR:

- https://github.com/rectorphp/rector-downgrade-php/pull/46

nullable parent should be skipped as allowed, see https://3v4l.org/aj0oW#v7.3.17