### PR TITLE
Upgrade downgrading enum nodes

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector/Fixture/enum_usage.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector/Fixture/enum_usage.php.inc
@@ -1,0 +1,76 @@
+<?php
+
+namespace App {
+    enum Enum: string
+    {
+        case ONE = 'one';
+        case TWO = 'two';
+        case THREE = 'three';
+
+        public function mixed(null|self|Enum|string $value)
+        {
+
+        }
+    }
+}
+namespace Tests{
+
+    use App\Enum;
+
+    class Analyser{
+        public function analyse(?\App\Enum $enum): Enum|bool
+        {
+            if ($enum === Enum::ONE) {
+                return Enum::TWO;
+            }
+            if ($enum === Enum::TWO) {
+                return false;
+            }
+            return $enum;
+        }
+    }
+}
+
+
+?>
+-----
+<?php
+
+namespace App {
+    class Enum
+    {
+        public const ONE = 'one';
+        public const TWO = 'two';
+        public const THREE = 'three';
+        /**
+         * @param (null | \App\Enum::* | string) $value
+         */
+        public function mixed(null|string $value)
+        {
+
+        }
+    }
+}
+namespace Tests{
+
+    use App\Enum;
+
+    class Analyser{
+        /**
+         * @param ?\App\Enum::* $enum
+         */
+        public function analyse(?string $enum): string|bool
+        {
+            if ($enum === Enum::ONE) {
+                return Enum::TWO;
+            }
+            if ($enum === Enum::TWO) {
+                return false;
+            }
+            return $enum;
+        }
+    }
+}
+
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector/Fixture/enum_without_type.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector/Fixture/enum_without_type.php.inc
@@ -1,0 +1,81 @@
+<?php
+
+enum NotBackedEnum
+{
+    case ONE;
+    case TWO;
+    case THREE;
+
+    public static function one(): self
+    {
+        return self::ONE;
+    }
+
+    public static function two(): static
+    {
+        return self::TWO;
+    }
+
+    public static function three(): NotBackedEnum
+    {
+        return self::THREE;
+    }
+
+    public static function oneValue(): string
+    {
+        return self::ONE->value;
+    }
+
+    public static function oneName(): string
+    {
+        return self::ONE->name;
+    }
+
+    public static function equalsTo(self $left, self $right): bool
+    {
+        return $left === $right;
+    }
+}
+
+
+?>
+-----
+<?php
+
+class NotBackedEnum
+{
+    public const ONE = 'one';
+    public const TWO = 'two';
+    public const THREE = 'three';
+    public static function one(): string
+    {
+        return self::ONE;
+    }
+    public static function two(): string
+    {
+        return self::TWO;
+    }
+    public static function three(): string
+    {
+        return self::THREE;
+    }
+    public static function oneValue(): string
+    {
+        return self::ONE;
+    }
+    public static function oneName(): string
+    {
+        return 'ONE';
+    }
+    /**
+     * @param \NotBackedEnum::* $left
+     * @param \NotBackedEnum::* $right
+     */
+    public static function equalsTo(string $left, string $right): bool
+    {
+        return $left === $right;
+    }
+}
+
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector/Fixture/int_enum.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector/Fixture/int_enum.php.inc
@@ -1,0 +1,81 @@
+<?php
+
+enum IntEnum: int
+{
+    case ONE = 1;
+    case TWO = 0;
+    case THREE = -1;
+
+    public static function one(): self
+    {
+        return self::ONE;
+    }
+
+    public static function two(): static
+    {
+        return self::TWO;
+    }
+
+    public static function three(): IntEnum
+    {
+        return self::THREE;
+    }
+
+    public static function oneValue(): int
+    {
+        return self::ONE->value;
+    }
+
+    public static function oneName(): string
+    {
+        return self::ONE->name;
+    }
+
+    public static function equalsTo(self $left, self $right): bool
+    {
+        return $left === $right;
+    }
+}
+
+
+?>
+-----
+<?php
+
+class IntEnum
+{
+    public const ONE = 1;
+    public const TWO = 0;
+    public const THREE = -1;
+    public static function one(): int
+    {
+        return self::ONE;
+    }
+    public static function two(): int
+    {
+        return self::TWO;
+    }
+    public static function three(): int
+    {
+        return self::THREE;
+    }
+    public static function oneValue(): int
+    {
+        return self::ONE;
+    }
+    public static function oneName(): string
+    {
+        return 'ONE';
+    }
+    /**
+     * @param \IntEnum::* $left
+     * @param \IntEnum::* $right
+     */
+    public static function equalsTo(int $left, int $right): bool
+    {
+        return $left === $right;
+    }
+}
+
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector/Fixture/string_enum.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector/Fixture/string_enum.php.inc
@@ -1,0 +1,81 @@
+<?php
+
+enum StringEnum: string
+{
+    case ONE = 'one';
+    case TWO = 'two';
+    case THREE = 'three';
+
+    public static function one(): self
+    {
+        return self::ONE;
+    }
+
+    public static function two(): static
+    {
+        return self::TWO;
+    }
+
+    public static function three(): StringEnum
+    {
+        return self::THREE;
+    }
+
+    public static function oneValue(): string
+    {
+        return self::ONE->value;
+    }
+
+    public static function oneName(): string
+    {
+        return self::ONE->name;
+    }
+
+    public static function equalsTo(self $left, self $right): bool
+    {
+        return $left === $right;
+    }
+}
+
+
+?>
+-----
+<?php
+
+class StringEnum
+{
+    public const ONE = 'one';
+    public const TWO = 'two';
+    public const THREE = 'three';
+    public static function one(): string
+    {
+        return self::ONE;
+    }
+    public static function two(): string
+    {
+        return self::TWO;
+    }
+    public static function three(): string
+    {
+        return self::THREE;
+    }
+    public static function oneValue(): string
+    {
+        return self::ONE;
+    }
+    public static function oneName(): string
+    {
+        return 'ONE';
+    }
+    /**
+     * @param \StringEnum::* $left
+     * @param \StringEnum::* $right
+     */
+    public static function equalsTo(string $left, string $right): bool
+    {
+        return $left === $right;
+    }
+}
+
+
+?>

--- a/rules/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector.php
+++ b/rules/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector.php
@@ -5,17 +5,22 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp80\Rector\Enum_;
 
 use PhpParser\Node;
+use PhpParser\Node\ComplexType;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\UnionType;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -39,28 +44,41 @@ final class DowngradeEnumToConstantListClassRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Downgrade enum to constant list class', [
-            new CodeSample(
-                <<<'CODE_SAMPLE'
-enum Direction
+        return new RuleDefinition(
+            'Downgrades enum and all it\'s usages to constant list class replaced the enum references to the enum baking type',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+enum Direction: string
 {
-    case LEFT;
+    case LEFT = 'left';
+    case RIGHT = 'right';
 
-    case RIGHT;
+    public function check(null|self|Enum|string $value): self
+    {
+        ...
+    }
 }
 CODE_SAMPLE
 
-                ,
-                <<<'CODE_SAMPLE'
+                    ,
+                    <<<'CODE_SAMPLE'
 class Direction
 {
     public const LEFT = 'left';
-
     public const RIGHT = 'right';
+    /**
+     * @param (null | \Direction::* | string) $value
+     */
+    public function check(null|string $value): string
+    {
+
+    }
 }
 CODE_SAMPLE
-            ),
-        ]);
+                ),
+            ]
+        );
     }
 
     /**
@@ -68,49 +86,41 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Enum_::class, ClassMethod::class];
+        return [
+            Enum_::class,
+            ClassMethod::class,
+            PropertyFetch::class,
+        ];
     }
 
     /**
      * @param Enum_|ClassMethod $node
      */
-    public function refactor(Node $node): Class_|ClassMethod|null
+    public function refactor(Node $node): mixed
     {
         if ($node instanceof Enum_) {
             return $this->classFromEnumFactory->createFromEnum($node);
+        }
+        if ($node instanceof PropertyFetch) {
+            return $this->replaceEnumToConstant($node);
         }
 
         $hasChanged = false;
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         foreach ($node->params as $param) {
-            if ($param->type instanceof Name) {
-                $paramType = $param->type;
-                $isNullable = false;
-            } elseif ($param->type instanceof NullableType) {
-                $paramType = $param->type->type;
-                $isNullable = true;
-            } else {
-                continue;
-            }
-
-            // is enum type?
-            /** @var string $typeName */
-            $typeName = $this->getName($paramType);
-            if (! $this->reflectionProvider->hasClass($typeName)) {
-                continue;
-            }
-
-            $classLikeReflection = $this->reflectionProvider->getClass($typeName);
-            if (! $classLikeReflection->isEnum()) {
-                continue;
-            }
-
-            $this->refactorParamType($classLikeReflection, $isNullable, $param);
+            $this->decorateParamDocType($param, $phpDocInfo);
+            $param->type = $this->renameEnumReference($param->type);
 
             $hasChanged = true;
+        }
+        if ($node->returnType !== null) {
+            $oldReturnType = $node->returnType;
 
-            $this->decorateParamDocType($classLikeReflection, $param, $phpDocInfo, $isNullable);
+            $node->returnType = $this->renameEnumReference($node->returnType);
+            if ($oldReturnType !== $node->returnType) {
+                $hasChanged = true;
+            }
         }
 
         if ($hasChanged) {
@@ -121,29 +131,100 @@ CODE_SAMPLE
     }
 
     private function decorateParamDocType(
-        ClassReflection $classReflection,
         Param $param,
         PhpDocInfo $phpDocInfo,
-        bool $isNullable
     ): void {
-        $constFetchNode = new ConstFetchNode('\\' . $classReflection->getName(), '*');
-        $constTypeNode = new ConstTypeNode($constFetchNode);
+        $nullable = false;
+        $paramType = $param->type;
+        if ($paramType instanceof UnionType) {
+            $types = [];
+            foreach ($paramType->types as $type) {
+                $classLikeReflection = $this->getClassReflectionByType($type);
+                if ($classLikeReflection === null) {
+                    $types[] = $type;
+                    continue;
+                }
+                $constFetchNode = new ConstFetchNode('\\' . $classLikeReflection->getName(), '*');
+                $types[$classLikeReflection->getName()] = new ConstTypeNode($constFetchNode);
+            }
+            $paramTypeNode = count($types) > 1 ? new UnionTypeNode($types) : new IdentifierTypeNode((string) $types[0]);
+        } else {
+            $nullable = $paramType instanceof NullableType;
+            $classLikeReflection = $this->getClassReflectionByType($paramType);
+            $typeName = $this->getName($paramType);
+            $typeNode = $classLikeReflection !== null
+                ? new ConstTypeNode(new ConstFetchNode('\\' . $classLikeReflection->getName(), '*'))
+                : new IdentifierTypeNode($typeName);
+            $paramTypeNode = $typeNode;
+        }
+        $paramTypeNode = $nullable ? new NullableTypeNode($paramTypeNode) : $paramTypeNode;
         $paramName = '$' . $this->getName($param);
-
-        $paramTypeNode = $isNullable ? new NullableTypeNode($constTypeNode) : $constTypeNode;
 
         $paramTagValueNode = new ParamTagValueNode($paramTypeNode, false, $paramName, '');
         $phpDocInfo->addTagValueNode($paramTagValueNode);
     }
 
-    private function refactorParamType(ClassReflection $classReflection, bool $isNullable, Param $param): void
+    private function replaceEnumToConstant(PropertyFetch $node): PropertyFetch|Node\Expr|Node\Scalar\String_
     {
-        $identifier = $this->enumAnalyzer->resolveType($classReflection);
-        if ($identifier instanceof Identifier) {
-            $param->type = $isNullable ? new NullableType($identifier) : new Name($identifier->name);
-        } else {
-            // remove type as ambiguous
-            $param->type = null;
+        if ((string) $node->name === 'value') {
+            return $node->var;
         }
+        if ((string) $node->name === 'name') {
+            return new Node\Scalar\String_($node->var->name->toString());
+        }
+
+        return $node;
+    }
+
+    private function renameEnumReference(null|ComplexType|Identifier|Name $type): null|ComplexType|Identifier|Name
+    {
+        if ($type instanceof UnionType) {
+            $types = [];
+            foreach ($type->types as &$innerType) {
+                $newType = $this->renameEnumReference($innerType);
+                $types[(string) $newType] = $newType;
+            }
+            $type->types = $types;
+            return $type;
+        }
+
+        $classLikeReflection = $this->getClassReflectionByType($type);
+        if ($classLikeReflection === null) {
+            return $type;
+        }
+        $identifier = $this->enumAnalyzer->resolveType($classLikeReflection);
+
+        if ($identifier !== null) {
+            if ($type instanceof NullableType) {
+                return new NullableType((string) $identifier);
+            }
+            return $identifier;
+        }
+
+        return null;
+    }
+
+    private function getClassReflectionByType(null|ComplexType|Identifier|Name $type,): ?ClassReflection
+    {
+        if ($type instanceof UnionType) {
+            foreach ($type->types as $type) {
+                $classReflection = $this->getClassReflectionByType($type);
+                if ($classReflection instanceof ClassReflection) {
+                    if ($classReflection->isEnum()) {
+                        return $classReflection;
+                    }
+                }
+            }
+            return null;
+        }
+        $typeName = $type instanceof NullableType ? (string) $type->type : (string) $type;
+        if (in_array($typeName, ['self', 'static'], true)) {
+            $class = $this->betterNodeFinder->findParentType($type, ClassLike::class);
+            return $this->reflectionProvider->getClass($this->getName($class));
+        }
+        if ($this->reflectionProvider->hasClass($typeName)) {
+            return $this->reflectionProvider->getClass($typeName);
+        }
+        return null;
     }
 }

--- a/rules/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector.php
+++ b/rules/DowngradePhp80/Rector/Enum_/DowngradeEnumToConstantListClassRector.php
@@ -86,11 +86,7 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [
-            Enum_::class,
-            ClassMethod::class,
-            PropertyFetch::class,
-        ];
+        return [Enum_::class, ClassMethod::class, PropertyFetch::class];
     }
 
     /**
@@ -130,10 +126,8 @@ CODE_SAMPLE
         return null;
     }
 
-    private function decorateParamDocType(
-        Param $param,
-        PhpDocInfo $phpDocInfo,
-    ): void {
+    private function decorateParamDocType(Param $param, PhpDocInfo $phpDocInfo): void
+    {
         $nullable = false;
         $paramType = $param->type;
         if ($paramType instanceof UnionType) {
@@ -204,7 +198,7 @@ CODE_SAMPLE
         return null;
     }
 
-    private function getClassReflectionByType(null|ComplexType|Identifier|Name $type,): ?ClassReflection
+    private function getClassReflectionByType(null|ComplexType|Identifier|Name $type): ?ClassReflection
     {
         if ($type instanceof UnionType) {
             foreach ($type->types as $type) {


### PR DESCRIPTION
- Value and name accessing replaced with it's values or references Enum::A->value => Enum::A, Enum::A->name => 'A'
- All possible references such as both return types and parameters types replace with backed type
- All `self` / `static` references inside enums also replace with backed types