### PR TITLE
Remove parent attribute usage on DowngradeArraySpreadRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -100,7 +100,3 @@ parameters:
             paths:
                 - tests
                 - rules-tests
-
-        -
-            message: '#Cognitive complexity for "Rector\\DowngradePhp74\\Rector\\Array_\\DowngradeArraySpreadRector\:\:refactorUnderClassConst\(\)" is 24, keep it under 10#'
-            path: rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php

--- a/rules/DowngradePhp56/NodeManipulator/UnpackedArgList.php
+++ b/rules/DowngradePhp56/NodeManipulator/UnpackedArgList.php
@@ -53,7 +53,7 @@ final class UnpackedArgList
     {
         if ($arg->value instanceof Array_) {
             foreach ($arg->value->items as $arrayItem) {
-                if ($arrayItem === null) {
+                if (! $arrayItem instanceof ArrayItem) {
                     continue;
                 }
 

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradeJsonDecodeNullAssociativeArgRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp72\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
@@ -88,7 +89,7 @@ CODE_SAMPLE
         $associativeValue = $args[1]->value;
 
         // already converted
-        if ($associativeValue instanceof Ternary && $associativeValue->if === null) {
+        if ($associativeValue instanceof Ternary && ! $associativeValue->if instanceof Expr) {
             return null;
         }
 

--- a/rules/DowngradePhp73/Rector/FuncCall/SetCookieOptionsArrayToArgumentsRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/SetCookieOptionsArrayToArgumentsRector.php
@@ -137,7 +137,7 @@ CODE_SAMPLE
         $optionsArray = $thirdArg->value;
         /** @var ArrayItem|null $arrayItem */
         foreach ($optionsArray->items as $arrayItem) {
-            if ($arrayItem === null) {
+            if (! $arrayItem instanceof ArrayItem) {
                 continue;
             }
 

--- a/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
+++ b/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
@@ -314,8 +314,8 @@ CODE_SAMPLE
             $nestedExprVariable = new ArrayDimFetch($nestedExprVariable, $nestedArrayIndexDim);
         }
 
-        $dim = BuilderHelpers::normalizeValue($arrayIndex);
-        $arrayDimFetch = new ArrayDimFetch($nestedExprVariable, $dim);
+        $expr = BuilderHelpers::normalizeValue($arrayIndex);
+        $arrayDimFetch = new ArrayDimFetch($nestedExprVariable, $expr);
         return new AssignRef($assignVariable, $arrayDimFetch);
     }
 
@@ -328,7 +328,7 @@ CODE_SAMPLE
         $itemsByRef = [];
 
         foreach ($arrayItems as $arrayItem) {
-            if ($arrayItem === null) {
+            if (! $arrayItem instanceof ArrayItem) {
                 continue;
             }
 

--- a/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
+++ b/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
@@ -18,7 +18,6 @@ use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\DowngradePhp81\NodeAnalyzer\ArraySpreadAnalyzer;
 use Rector\DowngradePhp81\NodeFactory\ArrayMergeFromArraySpreadFactory;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -85,24 +84,20 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Array_::class];
+        return [Array_::class, ClassConst::class];
     }
 
     /**
-     * @param Array_ $node
+     * @param Array_|ClassConst $node
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
-        if (! $this->arraySpreadAnalyzer->isArrayWithUnpack($node)) {
-            return null;
+        if ($node instanceof ClassConst) {
+            return $this->refactorUnderClassConst($node);
         }
 
-        $classConst = $this->betterNodeFinder->findParentType($node, ClassConst::class);
-        if ($classConst instanceof ClassConst) {
-            $refactorUnderClassConst = $this->refactorUnderClassConst($node, $classConst);
-            if ($refactorUnderClassConst instanceof Array_) {
-                return $refactorUnderClassConst;
-            }
+        if (! $this->arraySpreadAnalyzer->isArrayWithUnpack($node)) {
+            return null;
         }
 
         $shouldIncrement = (bool) $this->betterNodeFinder->findFirstNext($node, function (Node $subNode): bool {
@@ -117,37 +112,88 @@ CODE_SAMPLE
         return $this->arrayMergeFromArraySpreadFactory->createFromArray($node, $scope, $this->file, $shouldIncrement);
     }
 
-    private function refactorUnderClassConst(Array_ $array, ClassConst $classConst): ?Array_
+    private function refactorUnderClassConst(ClassConst $classConst): ?ClassConst
     {
-        $node = $classConst->getAttribute(AttributeKey::PARENT_NODE);
-        $hasChanged = false;
-
-        if (! $node instanceof ClassLike) {
+        $arrays = $this->betterNodeFinder->findInstanceOf($classConst->consts, Array_::class);
+        if ($arrays === []) {
             return null;
         }
 
+        $hasChanged = false;
+
+        foreach ($arrays as $array) {
+            $refactorArrayConstValue = $this->refactorArrayConstValue($array);
+            if ($refactorArrayConstValue instanceof Array_) {
+                $hasChanged = true;
+            }
+        }
+
+        if ($hasChanged) {
+            return $classConst;
+        }
+
+        return null;
+    }
+
+    private function resolveItemType(?ArrayItem $arrayItem): ?\PHPStan\Type\Type
+    {
+        if (! $arrayItem instanceof ArrayItem) {
+            return null;
+        }
+
+        if (! $arrayItem->unpack) {
+            return null;
+        }
+
+        if (! $arrayItem->value instanceof ClassConstFetch) {
+            return null;
+        }
+
+        if (! $arrayItem->value->class instanceof Name) {
+            return null;
+        }
+
+        if (! $arrayItem->value->name instanceof Identifier) {
+            return null;
+        }
+
+        return $this->nodeTypeResolver->getType($arrayItem->value->class);
+    }
+
+    private function refactorArrayConstValue(Array_ $array): ?Array_
+    {
+        $hasChanged = false;
+
         foreach ($array->items as $key => $item) {
-            if ($item instanceof ArrayItem && $item->unpack && $item->value instanceof ClassConstFetch && $item->value->class instanceof Name) {
-                $type = $this->nodeTypeResolver->getType($item->value->class);
-                $name = $item->value->name;
-                if ($type instanceof FullyQualifiedObjectType && $name instanceof Identifier) {
-                    $classLike = $this->astResolver->resolveClassFromName($type->getClassName());
-                    if (! $classLike instanceof ClassLike) {
-                        continue;
-                    }
+            $type = $this->resolveItemType($item);
+            if (! $type instanceof FullyQualifiedObjectType) {
+                continue;
+            }
 
-                    $constants = $classLike->getConstants();
+            /**
+             * @var ArrayItem $item
+             * @var ClassConstFetch $value
+             * @var Identifier $name
+             */
+            $value = $item->value;
+            /** @var Identifier $name */
+            $name = $value->name;
 
-                    foreach ($constants as $constant) {
-                        $const = $constant->consts[0];
+            $classLike = $this->astResolver->resolveClassFromName($type->getClassName());
+            if (! $classLike instanceof ClassLike) {
+                continue;
+            }
 
-                        if ($const->name instanceof Identifier && $const->name->toString() === $name->toString() && $const->value instanceof Array_) {
-                            unset($array->items[$key]);
-                            array_splice($array->items, $key, 0, $const->value->items);
+            $constants = $classLike->getConstants();
 
-                            $hasChanged = true;
-                        }
-                    }
+            foreach ($constants as $constant) {
+                $const = $constant->consts[0];
+
+                if ($const->name->toString() === $name->toString() && $const->value instanceof Array_) {
+                    unset($array->items[$key]);
+                    array_splice($array->items, $key, 0, $const->value->items);
+
+                    $hasChanged = true;
                 }
             }
         }

--- a/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
+++ b/rules/DowngradePhp74/Rector/Array_/DowngradeArraySpreadRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassLike;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\Scope;
+use PHPStan\Type\Type;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\DowngradePhp81\NodeAnalyzer\ArraySpreadAnalyzer;
@@ -135,7 +136,7 @@ CODE_SAMPLE
         return null;
     }
 
-    private function resolveItemType(?ArrayItem $arrayItem): ?\PHPStan\Type\Type
+    private function resolveItemType(?ArrayItem $arrayItem): ?Type
     {
         if (! $arrayItem instanceof ArrayItem) {
             return null;

--- a/rules/DowngradePhp74/Rector/FuncCall/DowngradeStripTagsCallWithArrayRector.php
+++ b/rules/DowngradePhp74/Rector/FuncCall/DowngradeStripTagsCallWithArrayRector.php
@@ -6,6 +6,7 @@ namespace Rector\DowngradePhp74\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
@@ -162,7 +163,7 @@ CODE_SAMPLE
         }
 
         // already refactored
-        if ($allowableTagsParam instanceof Ternary && $allowableTagsParam->if !== null) {
+        if ($allowableTagsParam instanceof Ternary && $allowableTagsParam->if instanceof Expr) {
             return true;
         }
 

--- a/rules/DowngradePhp80/NodeAnalyzer/UnnamedArgumentResolver.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/UnnamedArgumentResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp80\NodeAnalyzer;
 
 use PhpParser\Node\Arg;
+use PhpParser\Node\Identifier;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\Native\NativeFunctionReflection;
@@ -41,7 +42,7 @@ final class UnnamedArgumentResolver
         $toFillArgs = [];
 
         foreach ($currentArgs as $key => $arg) {
-            if ($arg->name === null) {
+            if (! $arg->name instanceof Identifier) {
                 $unnamedArgs[$key] = new Arg($arg->value, $arg->byRef, $arg->unpack, $arg->getAttributes(), null);
 
                 continue;

--- a/rules/DowngradePhp80/Rector/ArrayDimFetch/DowngradeDereferenceableOperationRector.php
+++ b/rules/DowngradePhp80/Rector/ArrayDimFetch/DowngradeDereferenceableOperationRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp80\Rector\ArrayDimFetch;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Scalar\Encapsed;
 use PhpParser\Node\Scalar\MagicConst;
@@ -65,7 +66,7 @@ CODE_SAMPLE
 
     private function shouldSkip(ArrayDimFetch $arrayDimFetch): bool
     {
-        if ($arrayDimFetch->dim === null) {
+        if (! $arrayDimFetch->dim instanceof Expr) {
             return true;
         }
 
@@ -87,7 +88,7 @@ CODE_SAMPLE
             return true;
         }
 
-        assert($arrayDimFetch->dim !== null); // already checked in shouldSkip()
+        assert($arrayDimFetch->dim instanceof Expr); // already checked in shouldSkip()
         $oldTokens = $this->file->getOldTokens();
         $varEndTokenPos = $arrayDimFetch->var->getEndTokenPos();
         $dimStartTokenPos = $arrayDimFetch->dim->getStartTokenPos();

--- a/rules/DowngradePhp80/Rector/Catch_/DowngradeNonCapturingCatchesRector.php
+++ b/rules/DowngradePhp80/Rector/Catch_/DowngradeNonCapturingCatchesRector.php
@@ -74,7 +74,7 @@ CODE_SAMPLE
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
-        if ($node->var !== null) {
+        if ($node->var instanceof Variable) {
             return null;
         }
 

--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -6,6 +6,7 @@ namespace Rector\DowngradePhp80\Rector\Class_;
 
 use PhpParser\Comment;
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
@@ -211,11 +212,12 @@ CODE_SAMPLE
             $property = new Property($param->flags, [new PropertyProperty($name)], [], $param->type);
             $this->decoratePropertyWithParamDocInfo($param, $property);
 
-            $hasNew = $param->default === null
-                ? false
-                : (bool) $this->betterNodeFinder->findFirstInstanceOf($param->default, New_::class);
+            $hasNew = $param->default instanceof Expr && (bool) $this->betterNodeFinder->findFirstInstanceOf(
+                $param->default,
+                New_::class
+            );
 
-            if ($param->default !== null && ! $hasNew) {
+            if ($param->default instanceof Expr && ! $hasNew) {
                 $property->props[0]->default = $param->default;
             }
 

--- a/rules/DowngradePhp81/NodeFactory/ArrayMergeFromArraySpreadFactory.php
+++ b/rules/DowngradePhp81/NodeFactory/ArrayMergeFromArraySpreadFactory.php
@@ -92,7 +92,7 @@ final class ArrayMergeFromArraySpreadFactory
 
         $accumulatedItems = [];
         foreach ($array->items as $position => $item) {
-            if ($item !== null && $item->unpack) {
+            if ($item instanceof ArrayItem && $item->unpack) {
                 // Spread operator found
                 if (! $item->value instanceof Variable) {
                     // If it is a not variable, transform it to a variable

--- a/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
+++ b/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
@@ -132,7 +132,7 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($param->default === null) {
+        if (! $param->default instanceof Expr) {
             return true;
         }
 

--- a/src/NodeAnalyzer/MethodCallTypeAnalyzer.php
+++ b/src/NodeAnalyzer/MethodCallTypeAnalyzer.php
@@ -60,6 +60,6 @@ final class MethodCallTypeAnalyzer
             return true;
         }
 
-        return $type->getAncestorWithClassName($expectedClass) !== null;
+        return $type->getAncestorWithClassName($expectedClass) instanceof TypeWithClassName;
     }
 }

--- a/src/NodeFactory/DoctrineAnnotationFactory.php
+++ b/src/NodeFactory/DoctrineAnnotationFactory.php
@@ -6,6 +6,7 @@ namespace Rector\NodeFactory;
 
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
@@ -44,7 +45,7 @@ final class DoctrineAnnotationFactory
             }
 
             $itemValue = $this->nodePrinter->print($arg->value);
-            if ($arg->name !== null) {
+            if ($arg->name instanceof Identifier) {
                 $name = $this->nodePrinter->print($arg->name);
                 $items[$name] = $itemValue;
             } else {

--- a/src/NodeManipulator/PropertyDecorator.php
+++ b/src/NodeManipulator/PropertyDecorator.php
@@ -8,6 +8,7 @@ use PhpParser\Node\ComplexType;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -24,7 +25,7 @@ final class PropertyDecorator
     public function decorateWithDocBlock(Property $property, ComplexType|Identifier|Name $typeNode): void
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
-        if ($phpDocInfo->getVarTagValueNode() !== null) {
+        if ($phpDocInfo->getVarTagValueNode() instanceof VarTagValueNode) {
             return;
         }
 


### PR DESCRIPTION
This PR continue of : 

- https://github.com/rectorphp/rector-downgrade-php/pull/52

which lookup parent from `Array_` to get `ClassConst`. 

To  increase performance, this PR add `ClassConst` at `getNodeTypes()` to lookup the `Array_` from its value intead.