### PR TITLE
[1.0] Use BetterNodeFinder::resolveNextNode() on DowngradeNegativeStringOffsetToStrlenRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpunit/phpunit": "^10.0",
         "rector/phpstan-rules": "^0.6",
         "rector/rector-generator": "^0.6.14",
-        "rector/rector-src": "dev-main",
+        "rector/rector-src": "dev-main#ec9789fd52862862addf0012cc143eb31dbfd01c",
         "symplify/easy-ci": "^11.2",
         "symplify/easy-coding-standard": "^11.2",
         "symplify/phpstan-extensions": "^11.1",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpunit/phpunit": "^10.0",
         "rector/phpstan-rules": "^0.6",
         "rector/rector-generator": "^0.6.14",
-        "rector/rector-src": "dev-main#ec9789fd52862862addf0012cc143eb31dbfd01c",
+        "rector/rector-src": "dev-main",
         "symplify/easy-ci": "^11.2",
         "symplify/easy-coding-standard": "^11.2",
         "symplify/phpstan-extensions": "^11.1",

--- a/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
+++ b/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
@@ -69,7 +69,7 @@ CODE_SAMPLE
     private function processForStringOrVariableOrProperty(
         String_ | Variable | PropertyFetch | StaticPropertyFetch $expr
     ): ?Expr {
-        $nextNode = $expr->getAttribute(AttributeKey::NEXT_NODE);
+        $nextNode = $this->betterNodeFinder->resolveNextNode($expr);
         if (! $nextNode instanceof UnaryMinus) {
             return null;
         }


### PR DESCRIPTION
@TomasVotruba @staabm this require PR on rector-src:

- https://github.com/rectorphp/rector-src/pull/3896

this cover next node of: `String_`, `Variable`, `PropertyFetch`, `StaticPropertyFetch`.

for adding `BetterNodeFinder::resolvePreviousNode()` and `BetterNodeFinder::resolveNextNode()` to be merged first.