### PR TITLE
[DowngradePhp80] Remove parent attribute on DowngradeAbstractPrivateMethodInTraitRector

### DIFF
--- a/rules/DowngradePhp70/Rector/FuncCall/DowngradeDirnameLevelsRector.php
+++ b/rules/DowngradePhp70/Rector/FuncCall/DowngradeDirnameLevelsRector.php
@@ -123,9 +123,9 @@ CODE_SAMPLE
         $funcVariable = $this->namedVariableFactory->createVariable($funcCall, 'dirnameFunc');
 
         $closure = $this->createClosure();
-        $exprAssignClosure = $this->createExprAssign($funcVariable, $closure);
+        $expression = $this->createExprAssign($funcVariable, $closure);
 
-        $this->nodesToAddCollector->addNodeBeforeNode($exprAssignClosure, $funcCall);
+        $this->nodesToAddCollector->addNodeBeforeNode($expression, $funcCall);
 
         $funcCall->name = $funcVariable;
 

--- a/rules/DowngradePhp80/Rector/ClassMethod/DowngradeAbstractPrivateMethodInTraitRector.php
+++ b/rules/DowngradePhp80/Rector/ClassMethod/DowngradeAbstractPrivateMethodInTraitRector.php
@@ -7,9 +7,9 @@ namespace Rector\DowngradePhp80\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Trait_;
+use PHPStan\Reflection\ClassReflection;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Core\Reflection\ReflectionResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -18,6 +18,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeAbstractPrivateMethodInTraitRector extends AbstractRector
 {
+    public function __construct(
+        private readonly ReflectionResolver $reflectionResolver
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -78,7 +83,11 @@ CODE_SAMPLE
             return true;
         }
 
-        $parentNode = $classMethod->getAttribute(AttributeKey::PARENT_NODE);
-        return ! $parentNode instanceof Trait_;
+        $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
+        if (! $classReflection instanceof ClassReflection) {
+            return true;
+        }
+
+        return ! $classReflection->isTrait();
     }
 }


### PR DESCRIPTION
Use `ReflectionResolver` instead.