### PR TITLE
[DowngradePhp73] Handle method call as arg on DowngradeArrayKeyFirstLastRector

### DIFF
--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeArrayKeyFirstLastRector\Fixture;
+
+use PhpParser\Node\Expr\MethodCall;
+
+class MethodCallAsArg
+{
+    public function run(MethodCall $node)
+    {
+        $lastItemKey = array_key_last($node->getArgs());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeArrayKeyFirstLastRector\Fixture;
+
+use PhpParser\Node\Expr\MethodCall;
+
+class MethodCallAsArg
+{
+    public function run(MethodCall $node)
+    {
+        $args = $node->getArgs();
+        end($args);
+        $lastItemKey = array_key_last($args);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg.php.inc
@@ -24,9 +24,9 @@ class MethodCallAsArg
 {
     public function run(MethodCall $node)
     {
-        $args = $node->getArgs();
-        end($args);
-        $lastItemKey = key($args);
+        $getArgs = $node->getArgs();
+        end($getArgs);
+        $lastItemKey = key($getArgs);
     }
 }
 

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg2.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg2.php.inc
@@ -8,7 +8,7 @@ class MethodCallAsArg2
 {
     public function run(MethodCall $node)
     {
-        $lastItemKey = array_key_first($node->getArgs());
+        $firstItemKey = array_key_first($node->getArgs());
     }
 }
 
@@ -26,7 +26,7 @@ class MethodCallAsArg2
     {
         $args = $node->getArgs();
         reset($args);
-        $lastItemKey = key($args);
+        $firstItemKey = key($args);
     }
 }
 

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg2.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg2.php.inc
@@ -24,9 +24,9 @@ class MethodCallAsArg2
 {
     public function run(MethodCall $node)
     {
-        $args = $node->getArgs();
-        reset($args);
-        $firstItemKey = key($args);
+        $getArgs = $node->getArgs();
+        reset($getArgs);
+        $firstItemKey = key($getArgs);
     }
 }
 

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg2.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg2.php.inc
@@ -4,11 +4,11 @@ namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeArrayKeyFirstLast
 
 use PhpParser\Node\Expr\MethodCall;
 
-class MethodCallAsArg
+class MethodCallAsArg2
 {
     public function run(MethodCall $node)
     {
-        $lastItemKey = array_key_last($node->getArgs());
+        $lastItemKey = array_key_first($node->getArgs());
     }
 }
 
@@ -20,12 +20,12 @@ namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeArrayKeyFirstLast
 
 use PhpParser\Node\Expr\MethodCall;
 
-class MethodCallAsArg
+class MethodCallAsArg2
 {
     public function run(MethodCall $node)
     {
         $args = $node->getArgs();
-        end($args);
+        reset($args);
         $lastItemKey = key($args);
     }
 }

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
@@ -152,8 +152,7 @@ CODE_SAMPLE
 
         if ($originalArray instanceof CallLike) {
             $scope = $originalArray->getAttribute(AttributeKey::SCOPE);
-            $variable = new Variable($this->variableNaming->createCountedValueName('args', $scope));
-            $array = $variable;
+            $array = new Variable($this->variableNaming->createCountedValueName('args', $scope));
         }
 
         if ($originalArray !== $array) {
@@ -200,8 +199,7 @@ CODE_SAMPLE
 
         if ($originalArray instanceof CallLike) {
             $scope = $originalArray->getAttribute(AttributeKey::SCOPE);
-            $variable = new Variable($this->variableNaming->createCountedValueName('args', $scope));
-            $array = $variable;
+            $array = new Variable($this->variableNaming->createCountedValueName('args', $scope));
         }
 
         if ($originalArray !== $array) {

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Cast\Array_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
@@ -34,7 +35,7 @@ final class DowngradeArrayKeyFirstLastRector extends AbstractRector
 {
     public function __construct(
         private readonly VariableNaming $variableNaming,
-        private readonly StmtMatcher $stmtMatcher,
+        private readonly StmtMatcher $stmtMatcher
     ) {
     }
 
@@ -147,8 +148,13 @@ CODE_SAMPLE
 
         $originalArray = $args[0]->value;
         $array = $this->resolveCastedArray($originalArray);
-
         $newStmts = [];
+
+        if ($originalArray instanceof CallLike) {
+            $scope = $originalArray->getAttribute(AttributeKey::SCOPE);
+            $variable = new Variable($this->variableNaming->createCountedValueName('args', $scope));
+            $array = $variable;
+        }
 
         if ($originalArray !== $array) {
             $newStmts[] = new Expression(new Assign($array, $originalArray));
@@ -191,6 +197,12 @@ CODE_SAMPLE
         $array = $this->resolveCastedArray($originalArray);
 
         $newStmts = [];
+
+        if ($originalArray instanceof CallLike) {
+            $scope = $originalArray->getAttribute(AttributeKey::SCOPE);
+            $variable = new Variable($this->variableNaming->createCountedValueName('args', $scope));
+            $array = $variable;
+        }
 
         if ($originalArray !== $array) {
             $newStmts[] = new Expression(new Assign($array, $originalArray));

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
@@ -18,6 +18,7 @@ use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
+use PHPStan\Analyser\Scope;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Naming\Naming\VariableNaming;
@@ -133,6 +134,11 @@ CODE_SAMPLE
         return $stmtsAware;
     }
 
+    private function resolveVariableFromCallLikeScope(?Scope $scope): Variable
+    {
+        return new Variable($this->variableNaming->createCountedValueName('args', $scope));
+    }
+
     /**
      * @return Stmt[]|StmtsAwareInterface|null
      */
@@ -152,7 +158,7 @@ CODE_SAMPLE
 
         if ($originalArray instanceof CallLike) {
             $scope = $originalArray->getAttribute(AttributeKey::SCOPE);
-            $array = new Variable($this->variableNaming->createCountedValueName('args', $scope));
+            $array = $this->resolveVariableFromCallLikeScope($scope);
         }
 
         if ($originalArray !== $array) {
@@ -199,7 +205,7 @@ CODE_SAMPLE
 
         if ($originalArray instanceof CallLike) {
             $scope = $originalArray->getAttribute(AttributeKey::SCOPE);
-            $array = new Variable($this->variableNaming->createCountedValueName('args', $scope));
+            $array = $this->resolveVariableFromCallLikeScope($scope);
         }
 
         if ($originalArray !== $array) {


### PR DESCRIPTION
@leoloso  @TomasVotruba continue for quick fix of PR:

- https://github.com/rectorphp/rector-downgrade-php/pull/85

this is to ensure no same issue happen again in the future by refactor `DowngradeArrayKeyFirstLastRector` to cover method call on `end()` or `key()`

Ref https://3v4l.org/TclSB