### PR TITLE
[Downgrade] Add TopStmtAndExprMatcher

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/Fixture/no_scope_parent_assign_from_func_call.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector/Fixture/no_scope_parent_assign_from_func_call.php.inc
@@ -39,24 +39,24 @@ final class Loop
         if (self::$instance instanceof LoopInterface) {
             return self::$instance;
         }
-        $arrayIsList = function (array $array) : bool {
-            if (function_exists('array_is_list')) {
-                return array_is_list($array);
-            }
-            if ($array === []) {
-                return true;
-            }
-            $current_key = 0;
-            foreach ($array as $key => $noop) {
-                if ($key !== $current_key) {
-                    return false;
-                }
-                ++$current_key;
-            }
-            return true;
-        };
 
-        register_shutdown_function(function () use($arrayIsList) {
+        register_shutdown_function(function () {
+            $arrayIsList = function (array $array) : bool {
+                if (function_exists('array_is_list')) {
+                    return array_is_list($array);
+                }
+                if ($array === []) {
+                    return true;
+                }
+                $current_key = 0;
+                foreach ($array as $key => $noop) {
+                    if ($key !== $current_key) {
+                        return false;
+                    }
+                    ++$current_key;
+                }
+                return true;
+            };
             $test = $arrayIsList([]);
         });
     }

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
@@ -10,9 +10,12 @@ use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Echo_;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\Switch_;
 use PHPStan\Analyser\Scope;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Parser\InlineCodeParser;
 use Rector\Core\Rector\AbstractScopeAwareRector;
@@ -79,12 +82,12 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return $this->topStmtAndExprMatcher->getStmts();
+        return [StmtsAwareInterface::class, Switch_::class, Return_::class, Expression::class, Echo_::class];
     }
 
     /**
-     * @param Stmt $node
-     * @return Stmt[]|null
+     * @param StmtsAwareInterface|Switch_|Return_|Expression|Echo_ $node
+     * @return Node[]|null
      */
     public function refactorWithScope(Node $node, Scope $scope): ?array
     {

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
@@ -8,13 +8,10 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\Expr\ClosureUse;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
-use PhpParser\Node\Stmt\If_;
-use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\Scope;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Parser\InlineCodeParser;
@@ -99,21 +96,22 @@ CODE_SAMPLE
                 }
 
                 return ! $this->shouldSkip($subNode);
-            });
+            }
+        );
 
         if (! $stmtAndExpr instanceof StmtAndExpr) {
             return null;
         }
 
         $stmt = $stmtAndExpr->getStmt();
-        /** @var FuncCall $funcCall */
-        $funcCall = $stmtAndExpr->getExpr();
+        /** @var FuncCall $expr */
+        $expr = $stmtAndExpr->getExpr();
         $variable = new Variable($this->variableNaming->createCountedValueName('arrayIsList', $scope));
 
         $function = $this->createClosure();
         $expression = new Expression(new Assign($variable, $function));
 
-        $funcCall->name = $variable;
+        $expr->name = $variable;
 
         return [$expression, $stmt];
     }

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeArrayIsListRector.php
@@ -21,6 +21,8 @@ use Rector\Core\PhpParser\Parser\InlineCodeParser;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\DowngradePhp72\NodeAnalyzer\FunctionExistsFunCallAnalyzer;
 use Rector\Naming\Naming\VariableNaming;
+use Rector\NodeAnalyzer\TopStmtAndExprMatcher;
+use Rector\ValueObject\StmtAndExpr;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -37,6 +39,7 @@ final class DowngradeArrayIsListRector extends AbstractScopeAwareRector
         private readonly InlineCodeParser $inlineCodeParser,
         private readonly FunctionExistsFunCallAnalyzer $functionExistsFunCallAnalyzer,
         private readonly VariableNaming $variableNaming,
+        private readonly TopStmtAndExprMatcher $topStmtAndExprMatcher
     ) {
     }
 
@@ -79,65 +82,40 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Expression::class, If_::class, Return_::class];
+        return $this->topStmtAndExprMatcher->getStmts();
     }
 
     /**
-     * @param Expression|If_|Return_ $node
+     * @param Stmt $node
      * @return Stmt[]|null
      */
     public function refactorWithScope(Node $node, Scope $scope): ?array
     {
-        /** @var FuncCall[] $funcCalls */
-        $funcCalls = $node instanceof If_
-            ? $this->betterNodeFinder->findInstanceOf($node->cond, FuncCall::class)
-            : $this->betterNodeFinder->findInstanceOf($node, FuncCall::class);
+        $stmtAndExpr = $this->topStmtAndExprMatcher->match(
+            $node,
+            function (Node $subNode): bool {
+                if (! $subNode instanceof FuncCall) {
+                    return false;
+                }
 
-        if ($funcCalls === []) {
+                return ! $this->shouldSkip($subNode);
+            });
+
+        if (! $stmtAndExpr instanceof StmtAndExpr) {
             return null;
         }
 
-        foreach ($funcCalls as $funcCall) {
-            if ($this->shouldSkip($funcCall)) {
-                continue;
-            }
+        $stmt = $stmtAndExpr->getStmt();
+        /** @var FuncCall $funcCall */
+        $funcCall = $stmtAndExpr->getExpr();
+        $variable = new Variable($this->variableNaming->createCountedValueName('arrayIsList', $scope));
 
-            $variable = new Variable($this->variableNaming->createCountedValueName('arrayIsList', $scope));
+        $function = $this->createClosure();
+        $expression = new Expression(new Assign($variable, $function));
 
-            $function = $this->createClosure();
-            $expression = new Expression(new Assign($variable, $function));
+        $funcCall->name = $variable;
 
-            $funcCall->name = $variable;
-
-            $this->applyUseClosure($node, $variable);
-
-            return [$expression, $node];
-        }
-
-        return null;
-    }
-
-    private function applyUseClosure(Expression|If_|Return_ $expression, Variable $variable): void
-    {
-        $expr = $expression instanceof If_ ? $expression->cond : $expression->expr;
-
-        if (! $expr instanceof CallLike) {
-            return;
-        }
-
-        if (! $this->shouldSkip($expr)) {
-            return;
-        }
-
-        if ($expr->isFirstClassCallable()) {
-            return;
-        }
-
-        foreach ($expr->getArgs() as $arg) {
-            if ($arg->value instanceof Closure) {
-                $arg->value->uses[] = new ClosureUse($variable);
-            }
-        }
+        return [$expression, $stmt];
     }
 
     private function createClosure(): Closure

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -30,7 +30,6 @@ final class TopStmtAndExprMatcher
     }
 
     /**
-     * @param Node|Node[] $stmt
      * @param callable(Node $node): bool $filter
      * @return null|array<Stmt, Expr>
      */

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -38,20 +38,16 @@ final class TopStmtAndExprMatcher
      */
     public function getStmts(): array
     {
-        return [
-            StmtsAwareInterface::class,
-            Switch_::class,
-            Return_::class,
-            Expression::class,
-            Echo_::class,
-        ];
+        return [StmtsAwareInterface::class, Switch_::class, Return_::class, Expression::class, Echo_::class];
     }
 
     /**
      * @param callable(Node $node): bool $filter
      */
-    public function match(StmtsAwareInterface|Switch_|Return_|Expression|Echo_ $stmt, callable $filter): null|StmtAndExpr
-    {
+    public function match(
+        StmtsAwareInterface|Switch_|Return_|Expression|Echo_ $stmt,
+        callable $filter
+    ): null|StmtAndExpr {
         if ($stmt instanceof Closure) {
             return null;
         }

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -70,13 +70,7 @@ final class TopStmtAndExprMatcher
                 return new StmtAndExpr($stmtsAware, $expr);
             }
         }
-
-        $stmtAndExprFromChildCond = $this->resolveFromChildCond($stmtsAware, $filter);
-        if ($stmtAndExprFromChildCond instanceof StmtAndExpr) {
-            return $stmtAndExprFromChildCond;
-        }
-
-        return null;
+        return $this->resolveFromChildCond($stmtsAware, $filter);
     }
 
     /**

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -34,6 +34,20 @@ final class TopStmtAndExprMatcher
     }
 
     /**
+     * @return array<class-string<StmtsAwareInterface|Switch_|Return_|Expression|Echo_>>
+     */
+    public function getStmts(): array
+    {
+        return [
+            StmtsAwareInterface::class,
+            Switch_::class,
+            Return_::class,
+            Expression::class,
+            Echo_::class,
+        ];
+    }
+
+    /**
      * @param callable(Node $node): bool $filter
      */
     public function match(StmtsAwareInterface|Switch_|Return_|Expression|Echo_ $stmt, callable $filter): null|StmtAndExpr

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -131,7 +131,7 @@ final class TopStmtAndExprMatcher
             return null;
         }
 
-        if ($stmtScope->getParentScope() === $exprScope->getParentScope()) {
+        if ($stmtScope->equals($exprScope)) {
             return $node;
         }
 

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\Echo_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Foreach_;
@@ -35,7 +36,7 @@ final class TopStmtAndExprMatcher
     /**
      * @param callable(Node $node): bool $filter
      */
-    public function match(StmtsAwareInterface|Switch_|Return_|Expression $stmt, callable $filter): null|StmtAndExpr
+    public function match(StmtsAwareInterface|Switch_|Return_|Expression|Echo_ $stmt, callable $filter): null|StmtAndExpr
     {
         if ($stmt instanceof Closure) {
             return null;
@@ -91,7 +92,7 @@ final class TopStmtAndExprMatcher
      * @param callable(Node $node): bool $filter
      */
     private function resolveFromChildCond(
-        StmtsAwareInterface|Switch_|Return_|Expression $stmt,
+        StmtsAwareInterface|Switch_|Return_|Expression|Echo_ $stmt,
         callable $filter
     ): null|StmtAndExpr {
         if (! $stmt instanceof If_ && ! $stmt instanceof Switch_) {

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -36,11 +36,12 @@ final class TopStmtAndExprMatcher
     public function match(StmtsAwareInterface $stmtsAware, callable $filter): null|array
     {
         if ($stmtsAware instanceof Foreach_) {
+            // keyVar can be null, filter only Expr
             $nodes = array_filter([$stmtsAware->expr, $stmtsAware->keyVar, $stmtsAware->valueVar]);
         }
 
         if ($stmtsAware instanceof For_) {
-            $nodes = array_filter([$stmtsAware->init, $stmtsAware->cond, $stmtsAware->loop]);
+            $nodes = [$stmtsAware->init, $stmtsAware->cond, $stmtsAware->loop];
         }
 
         if ($this->multiInstanceofChecker->isInstanceOf($stmtsAware, [

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -131,7 +131,7 @@ final class TopStmtAndExprMatcher
             return null;
         }
 
-        if ($stmtScope->equals($exprScope)) {
+        if ($stmtScope->getParentScope() === $exprScope->getParentScope()) {
             return $node;
         }
 

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -90,8 +90,10 @@ final class TopStmtAndExprMatcher
     /**
      * @param callable(Node $node): bool $filter
      */
-    private function resolveFromChildCond(StmtsAwareInterface|Switch_|Return_|Expression $stmt, callable $filter): null|StmtAndExpr
-    {
+    private function resolveFromChildCond(
+        StmtsAwareInterface|Switch_|Return_|Expression $stmt,
+        callable $filter
+    ): null|StmtAndExpr {
         if (! $stmt instanceof If_ && ! $stmt instanceof Switch_) {
             return null;
         }

--- a/src/NodeAnalyzer/TopStmtAndExprMatcher.php
+++ b/src/NodeAnalyzer/TopStmtAndExprMatcher.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeAnalyzer;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Switch_;
+use PhpParser\Node\Stmt\While_;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
+use Rector\Core\Util\MultiInstanceofChecker;
+
+/**
+ * To resolve Stmt and Expr in top StmtsAwareInterface from early Expr attribute
+ * so the usage can append code before the Stmt
+ */
+final class TopStmtAndExprMatcher
+{
+    public function __construct(
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly MultiInstanceofChecker $multiInstanceofChecker
+    ) {
+    }
+
+    /**
+     * @param Node|Node[] $stmt
+     * @param callable(Node $node): bool $filter
+     * @return null|array<Stmt, Expr>
+     */
+    public function match(StmtsAwareInterface $stmtsAware, callable $filter): null|array
+    {
+        if ($stmtsAware instanceof Foreach_) {
+            $nodes = array_filter([$stmtsAware->expr, $stmtsAware->keyVar, $stmtsAware->valueVar]);
+        }
+
+        if ($stmtsAware instanceof For_) {
+            $nodes = array_filter([$stmtsAware->init, $stmtsAware->cond, $stmtsAware->loop]);
+        }
+
+        if ($this->multiInstanceofChecker->isInstanceOf($stmtsAware, [
+            If_::class,
+            While_::class,
+            Do_::class,
+            Switch_::class,
+        ])) {
+            /** @var If_|While_|Do_|Switch_ $stmtsAware */
+            $nodes = [$stmtsAware->cond];
+        }
+
+        foreach ($nodes as $node) {
+            $expr = $this->betterNodeFinder->findFirst($node, $filter);
+            if ($expr instanceof Expr) {
+                return [$stmtsAware, $expr];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ValueObject/StmtAndExpr.php
+++ b/src/ValueObject/StmtAndExpr.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\ValueObject;
 
 use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt\Echo_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
@@ -13,12 +14,12 @@ use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 final class StmtAndExpr
 {
     public function __construct(
-        private readonly StmtsAwareInterface|Switch_|Return_|Expression $stmt,
+        private readonly StmtsAwareInterface|Switch_|Return_|Expression|Echo_ $stmt,
         private readonly Expr $expr,
     ) {
     }
 
-    public function getStmt(): StmtsAwareInterface|Switch_|Return_|Expression
+    public function getStmt(): StmtsAwareInterface|Switch_|Return_|Expression|Echo_
     {
         return $this->stmt;
     }

--- a/src/ValueObject/StmtAndExpr.php
+++ b/src/ValueObject/StmtAndExpr.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\ValueObject;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt\Switch_;
+use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+
+final class StmtAndExpr
+{
+    public function __construct(
+        private readonly StmtsAwareInterface|Switch_ $stmt,
+        private readonly Expr $expr,
+    ) {
+    }
+
+    public function getStmt(): StmtsAwareInterface|Switch_
+    {
+        return $this->stmt;
+    }
+
+    public function getExpr(): Expr
+    {
+        return $this->expr;
+    }
+}

--- a/src/ValueObject/StmtAndExpr.php
+++ b/src/ValueObject/StmtAndExpr.php
@@ -5,18 +5,20 @@ declare(strict_types=1);
 namespace Rector\ValueObject;
 
 use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
 
 final class StmtAndExpr
 {
     public function __construct(
-        private readonly StmtsAwareInterface|Switch_ $stmt,
+        private readonly StmtsAwareInterface|Switch_|Return_|Expression $stmt,
         private readonly Expr $expr,
     ) {
     }
 
-    public function getStmt(): StmtsAwareInterface|Switch_
+    public function getStmt(): StmtsAwareInterface|Switch_|Return_|Expression
     {
         return $this->stmt;
     }


### PR DESCRIPTION
This is part of issue:

- https://github.com/rectorphp/rector/issues/7975

to make downgrade more reliable to lookup Expr in top `StmtsAwareInterface` first, eg: on `If_`, it lookup on `cond`, then if exists, then return its stmt and expr so we can add new stmt before the stmt.