### PR TITLE
 [DowngradePhp80] Remove parent lookup on DowngradeMatchToSwitchRector 

### DIFF
--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -25,7 +25,9 @@ use PhpParser\Node\Stmt\Echo_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
+use PHPStan\Analyser\Scope;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Php72\NodeFactory\AnonymousFunctionFactory;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -36,7 +38,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\DowngradeMatchToSwitchRectorTest
  */
-final class DowngradeMatchToSwitchRector extends AbstractRector
+final class DowngradeMatchToSwitchRector extends AbstractScopeAwareRector
 {
     public function __construct(
         private readonly AnonymousFunctionFactory $anonymousFunctionFactory
@@ -97,7 +99,7 @@ CODE_SAMPLE
     /**
      * @param Echo_|Expression|Return_ $node
      */
-    public function refactor(Node $node): ?Node
+    public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
         $match = $this->betterNodeFinder->findFirst(
             $node,
@@ -107,8 +109,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $currentStmt = $this->betterNodeFinder->resolveCurrentStatement($match);
-        if ($currentStmt !== $node) {
+        $matchScope = $match->getAttribute(AttributeKey::SCOPE);
+        if (! $matchScope instanceof Scope) {
+            return null;
+        }
+
+        if ($matchScope->getParentScope() !== $scope->getParentScope()) {
             return null;
         }
 

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -26,7 +26,6 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Switch_;
 use PHPStan\Analyser\Scope;
-use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Php72\NodeFactory\AnonymousFunctionFactory;


### PR DESCRIPTION
instead of lookup via BetterNodeFinder to resolve current statement, compare via parent Scope instead.