### PR TITLE
Add test case for match + throws

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -88,3 +88,5 @@ parameters:
         -
             message: '#Use value object over return of values#'
             path: rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+
+        - '#New objects with "\$defaultExpr" name are overridden\. This can lead to unwanted bugs, please pick a different name to avoid it#'

--- a/tests/Set/Fixture/match_and_throw_expr.php.inc
+++ b/tests/Set/Fixture/match_and_throw_expr.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Set\Fixture;
+
+use InvalidArgumentException;
+
+final class MatchAndThrowExpr
+{
+    public function run($value)
+    {
+        return match ($value) {
+            1 => 'one',
+            2 => 'two',
+            default => throw new InvalidArgumentException()
+        };
+
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Set\Fixture;
+
+use InvalidArgumentException;
+
+final class MatchAndThrowExpr
+{
+    public function run($value)
+    {
+        return $value === 1 ? 'one' : ($value === 2 ? 'two' : null);
+
+    }
+}
+
+?>


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/commit/a8922f7431c9c9188be501107ee7819e0130da4c

We need to downgrade this propperly, to avoid exception as Expr, but as have is as a Stmt.

For now, we can go with the `null` stmt to make the result code at least runnable. 
Any ideas how to handle this better? :)