### PR TITLE
[DowngradePhp72] Handle crash on default null not part of Union on DowngradeParameterTypeWideningRector

### DIFF
--- a/rules-tests/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector/FixtureEmptyConfig/default_null_not_part_of_union.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector/FixtureEmptyConfig/default_null_not_part_of_union.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector\Fixture;
+
+class DefaultNullNotPartOfUnion
+{
+    /**
+     *
+     * @param int|string|array|null $children
+     */
+    public function addDefaultChildrenIfNoneSet(int|string|array $children = null)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\ClassMethod\DowngradeParameterTypeWideningRector\Fixture;
+
+class DefaultNullNotPartOfUnion
+{
+    /**
+     *
+     * @param int|string|array|null $children
+     */
+    public function addDefaultChildrenIfNoneSet($children = null)
+    {
+    }
+}
+
+?>

--- a/rules/DowngradePhp72/PhpDoc/NativeParamToPhpDocDecorator.php
+++ b/rules/DowngradePhp72/PhpDoc/NativeParamToPhpDocDecorator.php
@@ -70,6 +70,6 @@ final class NativeParamToPhpDocDecorator
         }
 
         // add default null type
-        return new UnionType([$paramType, new NullType()]);
+        return TypeCombinator::addNull($paramType);
     }
 }

--- a/rules/DowngradePhp72/PhpDoc/NativeParamToPhpDocDecorator.php
+++ b/rules/DowngradePhp72/PhpDoc/NativeParamToPhpDocDecorator.php
@@ -7,7 +7,6 @@ namespace Rector\DowngradePhp72\PhpDoc;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
-use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7994