### PR TITLE
feat(DowngradePhp73JsonConstRector): throw behavior

### DIFF
--- a/rules-tests/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector/Fixture/add_throw_on_json_decode_error.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector/Fixture/add_throw_on_json_decode_error.php.inc
@@ -1,0 +1,99 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\ConstFetch\DowngradePhp73JsonConstRector\Fixture;
+
+// Class
+class DowngradePhp73JsonConstRectorFixture
+{
+    public function method_json_decode(string $json): string | bool
+    {
+        try {
+            $payload = json_decode($json, null, 512, JSON_THROW_ON_ERROR);
+            return $payload;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function method_json_decode_multi_flags(string $json): string | bool
+    {
+        try {
+            $payload = json_decode($json, null, 512, JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
+            return $payload;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}
+
+// Function
+function func_json_decode(string $json): string | bool
+{
+    try {
+        $payload = json_decode($json, null, 512, JSON_THROW_ON_ERROR);
+        return $payload;
+    } catch (\Exception $e) {
+        return false;
+    }
+}
+
+// Standalone
+$decode = json_decode($json, null, 512, JSON_THROW_ON_ERROR);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\ConstFetch\DowngradePhp73JsonConstRector\Fixture;
+
+// Class
+class DowngradePhp73JsonConstRectorFixture
+{
+    public function method_json_decode(string $json): string | bool
+    {
+        try {
+            $payload = json_decode($json, null, 512, 0);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \Exception(json_last_error_msg());
+            }
+            return $payload;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function method_json_decode_multi_flags(string $json): string | bool
+    {
+        try {
+            $payload = json_decode($json, null, 512, JSON_OBJECT_AS_ARRAY);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \Exception(json_last_error_msg());
+            }
+            return $payload;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}
+
+// Function
+function func_json_decode(string $json): string | bool
+{
+    try {
+        $payload = json_decode($json, null, 512, 0);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception(json_last_error_msg());
+        }
+        return $payload;
+    } catch (\Exception $e) {
+        return false;
+    }
+}
+
+// Standalone
+$decode = json_decode($json, null, 512, 0);
+if (json_last_error() !== JSON_ERROR_NONE) {
+    throw new \Exception(json_last_error_msg());
+}
+
+?>

--- a/rules-tests/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector/Fixture/add_throw_on_json_encode_error.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector/Fixture/add_throw_on_json_encode_error.php.inc
@@ -1,0 +1,93 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\ConstFetch\DowngradePhp73JsonConstRector\Fixture;
+
+// Class
+class DowngradePhp73JsonConstRectorFixture
+{
+    public function method_json_encode(string $json): string | bool
+    {
+        try {
+            json_encode($json, JSON_THROW_ON_ERROR);
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function method_json_encode_multi_flags(string $json): string | bool
+    {
+        try {
+            json_encode($json, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}
+
+// Function
+function func_json_encode(string $json): string | bool
+{
+    try {
+        json_encode($json, JSON_THROW_ON_ERROR);
+    } catch (\Exception $e) {
+        return false;
+    }
+}
+
+// Standalone
+json_encode($json, JSON_THROW_ON_ERROR);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\ConstFetch\DowngradePhp73JsonConstRector\Fixture;
+
+// Class
+class DowngradePhp73JsonConstRectorFixture
+{
+    public function method_json_encode(string $json): string | bool
+    {
+        try {
+            json_encode($json, 0);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \Exception(json_last_error_msg());
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    public function method_json_encode_multi_flags(string $json): string | bool
+    {
+        try {
+            json_encode($json, JSON_PRETTY_PRINT);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new \Exception(json_last_error_msg());
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}
+
+// Function
+function func_json_encode(string $json): string | bool
+{
+    try {
+        json_encode($json, 0);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception(json_last_error_msg());
+        }
+    } catch (\Exception $e) {
+        return false;
+    }
+}
+
+// Standalone
+json_encode($json, 0);
+if (json_last_error() !== JSON_ERROR_NONE) {
+    throw new \Exception(json_last_error_msg());
+}
+
+?>

--- a/rules-tests/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector/Fixture/in_bitwise.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector/Fixture/in_bitwise.php.inc
@@ -25,6 +25,9 @@ class InBitwise
     public function run($argument)
     {
         $argument = json_encode($argument, JSON_UNESCAPED_SLASHES);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception(json_last_error_msg());
+        }
     }
 }
 

--- a/rules/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector.php
+++ b/rules/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector.php
@@ -49,6 +49,15 @@ CODE_SAMPLE
 json_encode($content, 0);
 CODE_SAMPLE
                 ),
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$content = json_decode($json, null, 512, JSON_THROW_ON_ERROR);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$content = json_decode($json, null, 512, 0);
+CODE_SAMPLE
+                ),
             ]
         );
     }

--- a/rules/DowngradePhp81/NodeFactory/ArrayMergeFromArraySpreadFactory.php
+++ b/rules/DowngradePhp81/NodeFactory/ArrayMergeFromArraySpreadFactory.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\MutatingScope;
-use PHPStan\Analyser\Scope;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\ObjectType;


### PR DESCRIPTION
Add a throwing error behavior after any `json_encode` or `json_decode` function called with the `JSON_THROW_ON_ERROR` flag set, since it will be removed.
This is a partial improvement of removing the `JSON_THROW_ON_ERROR` flag altogether without a proper alternative behavior, but that only works when the flags are directly set in the function call.
If the flags are set from a variable, that would require a much more complex analysis to be 100% accurate, probably beyond Rector actual capabilities.