### PR TITLE
[Test] Remove RunTestsInSeparateProcesses in tests

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/DowngradeMatchToSwitchRectorTest.php
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/DowngradeMatchToSwitchRectorTest.php
@@ -6,10 +6,8 @@ namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRe
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-#[RunTestsInSeparateProcesses]
 final class DowngradeMatchToSwitchRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector/DowngradeNewInInitializerRectorTest.php
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector/DowngradeNewInInitializerRectorTest.php
@@ -6,10 +6,8 @@ namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitiali
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-#[RunTestsInSeparateProcesses]
 final class DowngradeNewInInitializerRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]

--- a/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
+++ b/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
@@ -27,7 +27,6 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\UnionType;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
@@ -40,7 +39,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector\DowngradeNewInInitializerRectorTest
  */
-#[RunTestsInSeparateProcesses]
 final class DowngradeNewInInitializerRector extends AbstractRector
 {
     public function __construct(


### PR DESCRIPTION
After removed `gc_collect_cycles()` on PR:

- https://github.com/rectorphp/rector-src/pull/4472

the `RunTestsInSeparateProcesses` seems no longer needed.