### PR TITLE
[DowngradePhp80] Remove AttributeKey::INSIDE_ARRAY_ITEM usage on DowngradeMatchToSwitchRector

### DIFF
--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -247,8 +247,11 @@ CODE_SAMPLE
     /**
      * @return Case_[]
      */
-    private function createSwitchCasesFromMatchArms(Echo_ | Expression | Return_ $node, Match_ $match, bool $isInsideArrayItem = false): array
-    {
+    private function createSwitchCasesFromMatchArms(
+        Echo_ | Expression | Return_ $node,
+        Match_ $match,
+        bool $isInsideArrayItem = false
+    ): array {
         $switchCases = [];
 
         foreach ($match->arms as $matchArm) {

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
                     $subNode->value,
                     $scope
                 )) {
-                    $switchCases = $this->createSwitchCasesFromMatchArms($node, $subNode->value);
+                    $switchCases = $this->createSwitchCasesFromMatchArms($node, $subNode->value, true);
                     $switch = new Switch_($subNode->value->cond, $switchCases);
                     $subNode->value = new FuncCall($this->anonymousFunctionFactory->create([], [$switch], null));
 
@@ -247,11 +247,9 @@ CODE_SAMPLE
     /**
      * @return Case_[]
      */
-    private function createSwitchCasesFromMatchArms(Echo_ | Expression | Return_ $node, Match_ $match): array
+    private function createSwitchCasesFromMatchArms(Echo_ | Expression | Return_ $node, Match_ $match, bool $isInsideArrayItem = false): array
     {
         $switchCases = [];
-
-        $isInsideArrayItem = (bool) $match->getAttribute(AttributeKey::INSIDE_ARRAY_ITEM);
 
         foreach ($match->arms as $matchArm) {
             if (count((array) $matchArm->conds) > 1) {


### PR DESCRIPTION
`INSIDE_ARRAY_ITEM` attribtue only used once, and by this, this can be removed next on `ContextNodeVisitor`

https://github.com/rectorphp/rector-src/blob/77167c7a1047f430b68f7b1063b5f2cb8dfa9830/packages/NodeTypeResolver/PHPStan/Scope/NodeVisitor/ContextNodeVisitor.php#L56