### PR TITLE
Update DowngradePureIntersectionTypeRector fixtures to use FQCN

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpunit/phpunit": "^10.1",
         "rector/phpstan-rules": "^0.6",
         "rector/rector-generator": "^0.6",
-        "rector/rector-src": "dev-main",
+        "rector/rector-src": "dev-main#84b3ea107c6d5b5d369358cdfd7fc6e69d390e9d",
         "symplify/easy-ci": "^11.2",
         "symplify/easy-coding-standard": "^11.2",
         "symplify/phpstan-extensions": "^11.2",

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/function_arg_and_return_intersection.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/function_arg_and_return_intersection.php.inc
@@ -18,8 +18,8 @@ namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradePureIntersect
 use Baz\Bar;
 
 /**
- * @param (Baz\Bar & Qux) $var
- * @return (Baz\Bar & Qux)
+ * @param (\Baz\Bar & \Qux) $var
+ * @return (\Baz\Bar & \Qux)
  */
 function foo($var)
 {

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/function_arg_intersection.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/function_arg_intersection.php.inc
@@ -17,7 +17,7 @@ namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradePureIntersect
 use Baz\Bar;
 
 /**
- * @param (Baz\Bar & Qux) $var
+ * @param (\Baz\Bar & \Qux) $var
  */
 function foo($var)
 {

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/function_return_intersection.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/function_return_intersection.php.inc
@@ -17,7 +17,7 @@ namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradePureIntersect
 use Baz\Bar;
 
 /**
- * @return (Baz\Bar & Qux)
+ * @return (\Baz\Bar & \Qux)
  */
 function foo()
 {

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/method_arg_intersection.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/method_arg_intersection.php.inc
@@ -20,7 +20,7 @@ use Baz\Bar;
 final class SomeClass
 {
     /**
-     * @param (Baz\Bar & Qux) $value
+     * @param (\Baz\Bar & \Qux) $value
      */
     public function run($value)
     {

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/method_return_intersection.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradePureIntersectionTypeRector/Fixture/method_return_intersection.php.inc
@@ -20,7 +20,7 @@ use Baz\Bar;
 final class SomeClass
 {
     /**
-     * @return (Baz\Bar & Qux)
+     * @return (\Baz\Bar & \Qux)
      */
     public function run()
     {


### PR DESCRIPTION
@TomasVotruba this is temporary use `dev-main#84b3ea107c6d5b5d369358cdfd7fc6e69d390e9d` from PR:

- https://github.com/rectorphp/rector-src/pull/4598

to update `DowngradePureIntersectionTypeRector` fixtures to use FQCN.