### PR TITLE
Back to require rector/rector-src:dev-main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpunit/phpunit": "^10.1",
         "rector/phpstan-rules": "^0.6",
         "rector/rector-generator": "^0.6",
-        "rector/rector-src": "dev-main#84b3ea107c6d5b5d369358cdfd7fc6e69d390e9d",
+        "rector/rector-src": "dev-main",
         "symplify/easy-ci": "^11.2",
         "symplify/easy-coding-standard": "^11.2",
         "symplify/phpstan-extensions": "^11.2",


### PR DESCRIPTION
The intersection patch already merged at PR:

- https://github.com/rectorphp/rector-src/pull/4598

so it can use dev-main again.