### PR TITLE
[DowngradePhp80] Reset counter to 0 when changing file on DowngradeNullsafeToTernaryOperatorRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/get_nullable.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/get_nullable.php.inc
@@ -27,7 +27,7 @@ final class GetNullable
 {
     public function run($value)
     {
-        return ($nullsafeVariable6 = $this->extractArrayItemByKey($value)) ? $nullsafeVariable6->value : null;
+        return ($nullsafeVariable1 = $this->extractArrayItemByKey($value)) ? $nullsafeVariable1->value : null;
     }
 
     protected function extractArrayItemByKey($value): ?ArrayItem

--- a/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/get_nullable_in_trait.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/get_nullable_in_trait.php.inc
@@ -29,7 +29,7 @@ trait GetNullableInTrait
 {
     public function run($value)
     {
-        return ($nullsafeVariable7 = $this->extractArrayItemByKey($value)) ? $nullsafeVariable7->value : null;
+        return ($nullsafeVariable1 = $this->extractArrayItemByKey($value)) ? $nullsafeVariable1->value : null;
     }
 
     protected function extractArrayItemByKey($value): ?ArrayItem

--- a/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/multiple_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/multiple_call.php.inc
@@ -21,8 +21,8 @@ class MultipleCall
 {
     public function run($object)
     {
-        $result = ($nullsafeVariable8 = ($nullsafeVariable9 = $object->multiple($args1)) ? $nullsafeVariable9->call($args2) : null) ? $nullsafeVariable8->otherCall($args3) : null;
-        $result = ($nullsafeVariable10 = ($nullsafeVariable11 = ($nullsafeVariable12 = $object->multiple($args1)) ? $nullsafeVariable12->call($args2) : null) ? $nullsafeVariable11->otherCall($args3) : null) ? $nullsafeVariable10->anotherCall($args4) : null;
+        $result = ($nullsafeVariable1 = ($nullsafeVariable2 = $object->multiple($args1)) ? $nullsafeVariable2->call($args2) : null) ? $nullsafeVariable1->otherCall($args3) : null;
+        $result = ($nullsafeVariable3 = ($nullsafeVariable4 = ($nullsafeVariable5 = $object->multiple($args1)) ? $nullsafeVariable5->call($args2) : null) ? $nullsafeVariable4->otherCall($args3) : null) ? $nullsafeVariable3->anotherCall($args4) : null;
     }
 }
 

--- a/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
+++ b/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\Application\File;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -59,15 +60,23 @@ CODE_SAMPLE
     /**
      * @param NullsafeMethodCall|NullsafePropertyFetch $node
      */
-    public function refactor(Node $node): Ternary
+    public function refactor(Node $node): ?Ternary
     {
         if ($this->previousFileName === null) {
-            $this->previousFileName = $this->currentFileProvider->getFile()
-                ->getFilePath();
+            $previousFile = $this->currentFileProvider->getFile();
+            if (! $previousFile instanceof File) {
+                return null;
+            }
+
+            $this->previousFileName = $previousFile->getFilePath();
         }
 
-        $this->currentFileName = $this->currentFileProvider->getFile()
-            ->getFilePath();
+        $currentFile = $this->currentFileProvider->getFile();
+        if (! $currentFile instanceof File) {
+            return null;
+        }
+
+        $this->currentFileName = $currentFile->getFilePath();
 
         $nullsafeVariable = $this->createNullsafeVariable();
 

--- a/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
+++ b/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
@@ -25,10 +25,12 @@ final class DowngradeNullsafeToTernaryOperatorRector extends AbstractRector
     private int $counter = 0;
 
     private ?string $previousFileName = null;
+
     private ?string $currentFileName = null;
 
-    public function __construct(private readonly CurrentFileProvider $currentFileProvider)
-    {
+    public function __construct(
+        private readonly CurrentFileProvider $currentFileProvider
+    ) {
     }
 
     public function getRuleDefinition(): RuleDefinition
@@ -60,12 +62,14 @@ CODE_SAMPLE
     public function refactor(Node $node): Ternary
     {
         if ($this->previousFileName === null) {
-            $this->previousFileName = $this->currentFileProvider->getFile()->getFilePath();
+            $this->previousFileName = $this->currentFileProvider->getFile()
+                ->getFilePath();
         }
 
-        $this->currentFileName = $this->currentFileProvider->getFile()->getFilePath();
+        $this->currentFileName = $this->currentFileProvider->getFile()
+            ->getFilePath();
 
-        $nullsafeVariable = $this->createNullsafeVariable($this->previousFileName, $this->currentFileName);
+        $nullsafeVariable = $this->createNullsafeVariable();
 
         $methodCallOrPropertyFetch = $node instanceof NullsafeMethodCall
             ? new MethodCall($nullsafeVariable, $node->name, $node->getArgs())


### PR DESCRIPTION
@TomasVotruba when Rector enter different file, the counter should be reset to 0. This is to avoid keep changing counter in the downgrade build and make more reliable run tests between env.