### PR TITLE
[Downgradephp81] Use $node->isFirstClassCallable() on DowngradeFirstClassCallableSyntaxRector

### DIFF
--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeFirstClassCallableSyntaxRector.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\Node\VariadicPlaceholder;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -57,22 +56,13 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?StaticCall
     {
-        if ($this->shouldSkip($node)) {
+        if (! $node->isFirstClassCallable()) {
             return null;
         }
 
         $callbackExpr = $this->createCallback($node);
 
         return $this->createClosureFromCallableCall($callbackExpr);
-    }
-
-    private function shouldSkip(FuncCall|MethodCall|StaticCall $node): bool
-    {
-        if (count($node->getRawArgs()) !== 1) {
-            return true;
-        }
-
-        return ! $node->args[0] instanceof VariadicPlaceholder;
     }
 
     private function createCallback(FuncCall|MethodCall|StaticCall $node): String_|Array_|Expr


### PR DESCRIPTION
instead of manual check `VariadicPlaceholder`.