### PR TITLE
[Performance] Remove double validate ArraySpreadAnalyzer::isArrayWithUnpack() on ArrayMergeFromArraySpreadFactory

### DIFF
--- a/rules/DowngradePhp81/NodeFactory/ArrayMergeFromArraySpreadFactory.php
+++ b/rules/DowngradePhp81/NodeFactory/ArrayMergeFromArraySpreadFactory.php
@@ -18,24 +18,18 @@ use PHPStan\Type\IterableType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\DowngradePhp81\NodeAnalyzer\ArraySpreadAnalyzer;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 final class ArrayMergeFromArraySpreadFactory
 {
     public function __construct(
-        private readonly NodeNameResolver $nodeNameResolver,
-        private readonly ArraySpreadAnalyzer $arraySpreadAnalyzer
+        private readonly NodeNameResolver $nodeNameResolver
     ) {
     }
 
     public function createFromArray(Array_ $array, MutatingScope $mutatingScope): ?Node
     {
-        if (! $this->arraySpreadAnalyzer->isArrayWithUnpack($array)) {
-            return null;
-        }
-
         $newArrayItems = $this->disolveArrayItems($array);
         return $this->createArrayMergeFuncCall($newArrayItems, $mutatingScope);
     }

--- a/rules/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector.php
+++ b/rules/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector.php
@@ -67,6 +67,10 @@ CODE_SAMPLE
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
+        if (! $this->arraySpreadAnalyzer->isArrayWithUnpack($node)) {
+            return null;
+        }
+
         if ($this->shouldSkipArray($node)) {
             return null;
         }
@@ -77,10 +81,6 @@ CODE_SAMPLE
 
     private function shouldSkipArray(Array_ $array): bool
     {
-        if (! $this->arraySpreadAnalyzer->isArrayWithUnpack($array)) {
-            return true;
-        }
-
         foreach ($array->items as $item) {
             if (! $item instanceof ArrayItem) {
                 continue;


### PR DESCRIPTION
Already called in the rules that uses it.