### PR TITLE
[DowngradePhp80] Do not change correct union array docblock on DowngradeUnionTypeDeclarationRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeUnionTypeDeclarationRector/Fixture/do_not_change_correct_union_array_docblock_on_param2.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/FunctionLike/DowngradeUnionTypeDeclarationRector/Fixture/do_not_change_correct_union_array_docblock_on_param2.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeUnionTypeDeclarationRector\Fixture;
+
+use PhpParser\Node;
+
+final class DoNotChangeCorrectUnionArrayDocblockOnParam2
+{
+    /**
+     * @param Node|Node[] $node
+     */
+    function execute(Node | array $node): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\FunctionLike\DowngradeUnionTypeDeclarationRector\Fixture;
+
+use PhpParser\Node;
+
+final class DoNotChangeCorrectUnionArrayDocblockOnParam2
+{
+    /**
+     * @param Node|Node[] $node
+     */
+    function execute($node): void
+    {
+    }
+}
+
+?>

--- a/rules/DowngradePhp73/Tokenizer/FollowedByNewlineOnlyMaybeWithSemicolonAnalyzer.php
+++ b/rules/DowngradePhp73/Tokenizer/FollowedByNewlineOnlyMaybeWithSemicolonAnalyzer.php
@@ -21,6 +21,6 @@ final class FollowedByNewlineOnlyMaybeWithSemicolonAnalyzer
 
         return ! isset($oldTokens[$nextTokenPosition]) ||
             isset($oldTokens[$nextTokenPosition][1]) &&
-            \str_starts_with((string) $oldTokens[$nextTokenPosition][1], "\n");
+            \str_starts_with($oldTokens[$nextTokenPosition][1], "\n");
     }
 }

--- a/src/PhpDocDecorator/PhpDocFromTypeDeclarationDecorator.php
+++ b/src/PhpDocDecorator/PhpDocFromTypeDeclarationDecorator.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
@@ -25,7 +26,6 @@ use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
@@ -51,8 +51,7 @@ final class PhpDocFromTypeDeclarationDecorator
         private readonly PhpAttributeGroupFactory $phpAttributeGroupFactory,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
-        private readonly PhpVersionProvider $phpVersionProvider,
-        private readonly TypeComparator $typeComparator
+        private readonly PhpVersionProvider $phpVersionProvider
     ) {
         $this->classMethodWillChangeReturnTypes = [
             // @todo how to make list complete? is the method list needed or can we use just class names?
@@ -231,7 +230,7 @@ final class PhpDocFromTypeDeclarationDecorator
         $paramName = $this->nodeNameResolver->getName($param);
 
         $phpDocParamType = $phpDocInfo->getParamType($paramName);
-        if ($type::class === $phpDocParamType::class) {
+        if (! $type instanceof MixedType && $type::class === $phpDocParamType::class) {
             return;
         }
 


### PR DESCRIPTION
Ref https://getrector.com/demo/3754a875-eb9f-4731-a52e-0f1ef8eeb441
Fixes https://github.com/rectorphp/rector/issues/8004