### PR TITLE
[DowngradePhp81] Fix algo not on list on DowngradeHashAlgorithmXxHashRector

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_hash_not_on_list.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_hash_not_on_list.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeHashAlgorithmXxHash\Fixture;
+
+class SkipHashNotOnList
+{
+    public function run($arg)
+    {
+        return hash($arg, 'some-data-to-hash');
+    }
+}

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
@@ -93,12 +93,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $arg = $node->args[$this->argNamedKey];
-
-        if (! $arg instanceof Arg) {
-            throw new ShouldNotHappenException();
+        $args = $node->getArgs();
+        if (! isset($args[$this->argNamedKey])) {
+            return null;
         }
 
+        $arg = $args[$this->argNamedKey];
         $arg->value = new String_(self::REPLACEMENT_ALGORITHM);
 
         return $node;

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
@@ -87,8 +87,7 @@ CODE_SAMPLE
         $this->argNamedKey = 0;
 
         $algorithm = $this->getHashAlgorithm($node->getArgs());
-
-        if (! array_key_exists($algorithm, self::HASH_ALGORITHMS_TO_DOWNGRADE)) {
+        if ($algorithm === null || ! array_key_exists($algorithm, self::HASH_ALGORITHMS_TO_DOWNGRADE)) {
             return null;
         }
 

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
     /**
      * @param Arg[] $args
      */
-    private function getHashAlgorithm(array $args): string
+    private function getHashAlgorithm(array $args): ?string
     {
         $arg = null;
 
@@ -137,7 +137,7 @@ CODE_SAMPLE
             $algorithmNode instanceof ConstFetch => $this->mapConstantToString(
                 $this->valueResolver->getValue($algorithmNode)
             ),
-            default => throw new ShouldNotHappenException(),
+            default => null,
         };
     }
 

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
@@ -106,6 +106,10 @@ CODE_SAMPLE
 
     private function shouldSkip(FuncCall $funcCall): bool
     {
+        if ($funcCall->isFirstClassCallable()) {
+            return true;
+        }
+
         return ! $this->nodeNameResolver->isName($funcCall, 'hash');
     }
 


### PR DESCRIPTION
@malteschlueter @TomasVotruba  this is to fix downgrade error:

```

Run php -d memory_limit=-1 bin/rector process rector-build/bin rector-build/config rector-build/src rector-build/packages rector-build/rules rector-build/vendor --config build/config/config-downgrade.php --ansi --no-diffs
    0/2542 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
  510/2542 [▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░]  20%
 1020/2542 [▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░]  40%
 1530/2542 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░]  60%
 2040/2542 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░]  80%

                                                                                
 [ERROR] Could not process                                                      
         "/home/runner/work/rector-src/rector-src/rector-build/src/Util/FileHash
         er.php" file, due to:                                                  
         "System error: "Look at                                                
         "Rector\DowngradePhp81\Rector\FuncCall\DowngradeHashAlgorithmXxHashRect
         or::getHashAlgorithm()"140"                                            
         Run Rector with "--debug" option and post the report here: 
https://github.com/rectorphp/rector/issues/new
". On line:
```