### PR TITLE
DowngradeTo74: Fix rector rule if ReflectionClass is nullable

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector/Fixture/class_is_nullable.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector/Fixture/class_is_nullable.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\MethodCall\DowngradeReflectionGetAttributesRector\Fixture;
+
+class SomeClass
+{
+    public function run(?\ReflectionClass $reflectionClass)
+    {
+        if ($reflectionClass->getAttributes('SomeAttribute')[0] ?? null) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\MethodCall\DowngradeReflectionGetAttributesRector\Fixture;
+
+class SomeClass
+{
+    public function run(?\ReflectionClass $reflectionClass)
+    {
+        if ((method_exists($reflectionClass, 'getAttributes') ? $reflectionClass->getAttributes('SomeAttribute') : [])[0] ?? null) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+?>

--- a/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
+++ b/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
@@ -234,15 +234,12 @@ CODE_SAMPLE
             // Nested list. Combine with the nodes from the recursive call
             /** @var List_ $nestedList */
             $nestedList = $listItem->value;
-            $listNestedArrayIndexes = array_merge($nestedArrayIndexes, [$key]);
-            $newNodes = array_merge(
-                $newNodes,
-                $this->createAssignRefArrayFromListReferences(
-                    $nestedList->items,
-                    $exprVariable,
-                    $listNestedArrayIndexes
-                )
-            );
+            $listNestedArrayIndexes = [...$nestedArrayIndexes, $key];
+            $newNodes = [...$newNodes, ...$this->createAssignRefArrayFromListReferences(
+                $nestedList->items,
+                $exprVariable,
+                $listNestedArrayIndexes
+            )];
         }
 
         return $newNodes;

--- a/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
+++ b/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
@@ -173,7 +173,7 @@ CODE_SAMPLE
 
         // parent classes or implemented interfaces
         /** @var ClassReflection[] $parentClassReflections */
-        $parentClassReflections = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        $parentClassReflections = [...$classReflection->getParents(), ...$classReflection->getInterfaces()];
 
         foreach ($parentClassReflections as $parentClassReflection) {
             $parentReflectionMethod = $this->resolveParentReflectionMethod($parentClassReflection, $methodName);

--- a/rules/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
+++ b/rules/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
@@ -173,7 +173,7 @@ CODE_SAMPLE
         $methodName = $this->getName($classMethod);
 
         /** @var ClassReflection[] $parentClassesAndInterfaces */
-        $parentClassesAndInterfaces = array_merge($classReflection->getParents(), $classReflection->getInterfaces());
+        $parentClassesAndInterfaces = [...$classReflection->getParents(), ...$classReflection->getInterfaces()];
 
         return $this->resolveMatchingReturnType($parentClassesAndInterfaces, $methodName, $classMethod, $returnType);
     }

--- a/rules/DowngradePhp74/Rector/Interface_/DowngradePreviouslyImplementedInterfaceRector.php
+++ b/rules/DowngradePhp74/Rector/Interface_/DowngradePreviouslyImplementedInterfaceRector.php
@@ -89,10 +89,10 @@ CODE_SAMPLE
                 continue;
             }
 
-            $collectInterfaces = array_merge(
-                $collectInterfaces,
-                $this->familyRelationsAnalyzer->getClassLikeAncestorNames($extend)
-            );
+            $collectInterfaces = [
+                ...$collectInterfaces,
+                ...$this->familyRelationsAnalyzer->getClassLikeAncestorNames($extend),
+            ];
         }
 
         if (! $isCleaned) {

--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -193,7 +193,7 @@ CODE_SAMPLE
 
         /** @var ClassMethod $constructorClassMethod */
         $constructorClassMethod = $class->getMethod(MethodName::CONSTRUCT);
-        $constructorClassMethod->stmts = array_merge($assigns, (array) $constructorClassMethod->stmts);
+        $constructorClassMethod->stmts = [...$assigns, ...(array) $constructorClassMethod->stmts];
     }
 
     /**

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
@@ -80,7 +80,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->isObjectType($node->var, new ObjectType('Reflector'))) {
+        if (
+            ! $this->isObjectType($node->var, new ObjectType('Reflector'))
+            && ! $this->isObjectType($node->var, new ObjectType('ReflectionClass'))
+        ) {
             return null;
         }
 


### PR DESCRIPTION
Currently Rector will do nothing which causes errors in PHP 7.4, see https://getrector.com/demo/8519d581-e93f-4d8b-8de4-956051503436.

The thing is that the following condition will result in a [`TrinaryLogic::createMaybe()`](https://github.com/phpstan/phpstan-src/blob/82364923b52079d20c23d38b8db2a1f9d2bdbfaf/src/Type/ObjectType.php#L398) but the method `isObjectType` returns `true` only on a `TrinaryLogic::YES`
https://github.com/rectorphp/rector-downgrade-php/blob/2d20783f344dec1895e19d2797d4c3b903b4f3cb/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php#L83

Because of that I added the explicit comparison with the `ReflectionClass`.