### PR TITLE
Remove unnecessary check ReflectionClass on DowngradeReflectionGetAttributesRector

### DIFF
--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionGetAttributesRector.php
@@ -80,10 +80,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (
-            ! $this->isObjectType($node->var, new ObjectType('Reflector'))
-            && ! $this->isObjectType($node->var, new ObjectType('ReflectionClass'))
-        ) {
+        if (! $this->isObjectType($node->var, new ObjectType('Reflector'))) {
             return null;
         }
 


### PR DESCRIPTION
@malteschlueter Per PR on rector-src

- https://github.com/rectorphp/rector-src/pull/5224

instanceof ReflectionClass no longer needed as it is instanceof Reflector.