### PR TITLE
[DowngradePhp73] Handle next if with BooleanOr condition that cause possible non-array data on DowngradeArrayKeyFirstLastRector

### DIFF
--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/possible_non_array_or_object_array_key_first.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/possible_non_array_or_object_array_key_first.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeArrayKeyFirstLastRector\Fixture;
+
+class PossibleNonArrayOrObjectArrayKeyFirst
+{
+    protected mixed $value = null;
+
+    private function run(): bool
+    {
+        $v = $this->value;
+
+        if (!\is_array($v) || 1 !== \count($v) || 10 !== \strlen($k = (string) array_key_first($v)) || "\x9D" !== $k[0] || "\0" !== $k[5] || "\x5F" !== $k[9]) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeArrayKeyFirstLastRector\Fixture;
+
+class PossibleNonArrayOrObjectArrayKeyFirst
+{
+    protected mixed $value = null;
+
+    private function run(): bool
+    {
+        $v = $this->value;
+        if (is_array($v)) {
+            reset($v);
+        }
+
+        if (!\is_array($v) || 1 !== \count($v) || 10 !== \strlen($k = (string) key($v)) || "\x9D" !== $k[0] || "\0" !== $k[5] || "\x5F" !== $k[9]) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/possible_non_array_or_object_array_key_last.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/possible_non_array_or_object_array_key_last.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeArrayKeyFirstLastRector\Fixture;
+
+class PossibleNonArrayOrObjectArrayKeyLast
+{
+    protected mixed $value = null;
+
+    private function run(): bool
+    {
+        $v = $this->value;
+
+        if (!\is_array($v) || 1 !== \count($v) || 10 !== \strlen($k = (string) array_key_last($v)) || "\x9D" !== $k[0] || "\0" !== $k[5] || "\x5F" !== $k[9]) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp73\Rector\FuncCall\DowngradeArrayKeyFirstLastRector\Fixture;
+
+class PossibleNonArrayOrObjectArrayKeyLast
+{
+    protected mixed $value = null;
+
+    private function run(): bool
+    {
+        $v = $this->value;
+        if (is_array($v)) {
+            end($v);
+        }
+
+        if (!\is_array($v) || 1 !== \count($v) || 10 !== \strlen($k = (string) key($v)) || "\x9D" !== $k[0] || "\0" !== $k[5] || "\x5F" !== $k[9]) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+?>


### PR DESCRIPTION
@leoloso this should fix https://github.com/rectorphp/rector/issues/8321 , only check next stmt is If_ with it inside `BooleanOr` is enough check I think, and only check `is_array()` is ok, since passed data will need to be array on check `array_key_last()` and `array_key_first()`  except we got more complex if usage on symfony :)