### PR TITLE
[DowngradePhp80] Handle match as arg on DowngradeMatchToSwitchRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/call_anonymous_function.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/call_anonymous_function.php.inc
@@ -22,17 +22,16 @@ $output = function($value) {
     echo $value;
 };
 
-switch ($statusCode) {
-    case 100:
-    case 200:
-        $output(null);
-        break;
-    case 300:
-        $output('not found');
-        break;
-    default:
-        $output('unknown status code');
-        break;
-}
+$output((function () use ($statusCode) {
+    switch ($statusCode) {
+        case 100:
+        case 200:
+            return null;
+        case 300:
+            return 'not found';
+        default:
+            return 'unknown status code';
+    }
+})());
 
 ?>

--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/function_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/function_call.php.inc
@@ -34,18 +34,17 @@ class FunctionCall
 {
     public function run($statusCode)
     {
-        switch ($statusCode) {
-            case 200:
-            case 300:
-                output(null);
-                break;
-            case 400:
-                output('not found');
-                break;
-            default:
-                output('unknown status code');
-                break;
-        }
+        output((function () use ($statusCode) {
+            switch ($statusCode) {
+                case 200:
+                case 300:
+                    return null;
+                case 400:
+                    return 'not found';
+                default:
+                    return 'unknown status code';
+            }
+        })());
     }
 }
 

--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/match_as_arg.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/match_as_arg.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+final class MatchAsArg
+{
+    public function run($param)
+    {
+        return execute(
+            match ($param) {
+                true => 1,
+                false => new \stdClass(),
+            },
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector\Fixture;
+
+final class MatchAsArg
+{
+    public function run($param)
+    {
+        return execute(
+            (function () use ($param) {
+                switch ($param) {
+                    case true:
+                        return 1;
+                    case false:
+                        return new \stdClass();
+                }
+            })(),
+        );
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/method_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/method_call.php.inc
@@ -34,18 +34,17 @@ class ClassFunctionCall
 
     public function run($statusCode)
     {
-        switch ($statusCode) {
-            case 200:
-            case 300:
-                $this->output(null);
-                break;
-            case 400:
-                $this->output('not found');
-                break;
-            default:
-                $this->output('unknown status code');
-                break;
-        }
+        $this->output((function () use ($statusCode) {
+            switch ($statusCode) {
+                case 200:
+                case 300:
+                    return null;
+                case 400:
+                    return 'not found';
+                default:
+                    return 'unknown status code';
+            }
+        })());
     }
 }
 

--- a/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/static_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector/Fixture/static_call.php.inc
@@ -34,18 +34,17 @@ class SomeStaticCall
 
     public function run($statusCode)
     {
-        switch ($statusCode) {
-            case 200:
-            case 300:
-                self::output(null);
-                break;
-            case 400:
-                self::output('not found');
-                break;
-            default:
-                self::output('unknown status code');
-                break;
-        }
+        self::output((function () use ($statusCode) {
+            switch ($statusCode) {
+                case 200:
+                case 300:
+                    return null;
+                case 400:
+                    return 'not found';
+                default:
+                    return 'unknown status code';
+            }
+        })());
     }
 }
 

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -108,7 +108,7 @@ CODE_SAMPLE
         $this->traverseNodesWithCallable(
             $node,
             function (Node $subNode) use ($node, &$match, &$hasChanged, $scope) {
-                if ($subNode instanceof ArrayItem && $subNode->value instanceof Match_ && $this->isEqualScope(
+                if (($subNode instanceof ArrayItem || $subNode instanceof Arg) && $subNode->value instanceof Match_ && $this->isEqualScope(
                     $subNode->value,
                     $scope
                 )) {


### PR DESCRIPTION
@ian-zunderdorp this should fix https://github.com/rectorphp/rector/issues/8369

I found that convert match as arg as invokable closure as your suggestion seems ok. let's try it.