### PR TITLE
[DowngradePhp73] Ensure reset() after go to end() array on DowngradeArrayKeyFirstLastRector

### DIFF
--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/array_key_last.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/array_key_last.php.inc
@@ -22,6 +22,7 @@ class SomeClass
     {
         end($items);
         $lastItemKey = key($items);
+        reset($items);
     }
 }
 

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/cast_array_key_last_value.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/cast_array_key_last_value.php.inc
@@ -27,6 +27,7 @@ class CastArrayKeyLastValue
         $stmts = (array) $classMethod->stmts;
         end($stmts);
         $lastItemKey = key($stmts);
+        reset($stmts);
     }
 }
 

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/double_cast.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/double_cast.php.inc
@@ -27,6 +27,7 @@ class DoubleCast
         $stmts = (array)(array) $classMethod->stmts;
         end($stmts);
         $lastItemKey = key($stmts);
+        reset($stmts);
     }
 }
 

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/inside_if_cond.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/inside_if_cond.php.inc
@@ -26,6 +26,7 @@ final class InsideIfCond
     {
         end($items);
         if (key($items)) {
+            reset($items);
             return true;
         } else {
             return false;

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/keep_inside_else.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/keep_inside_else.php.inc
@@ -29,6 +29,7 @@ final class KeepInsideIf
         } else {
             end($argumentValue);
             $this->completionValue = $argumentValue ? $argumentValue[key($argumentValue)] : null;
+            reset($argumentValue);
         }
     }
 }

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/keep_inside_if.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/keep_inside_if.php.inc
@@ -27,6 +27,7 @@ final class KeepInsideIf
         if (\is_array($argumentValue)) {
             end($argumentValue);
             $this->completionValue = $argumentValue ? $argumentValue[key($argumentValue)] : null;
+            reset($argumentValue);
         }
     }
 }

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/method_call_as_arg.php.inc
@@ -27,6 +27,7 @@ class MethodCallAsArg
         $getArgs = $node->getArgs();
         end($getArgs);
         $lastItemKey = key($getArgs);
+        reset($getArgs);
     }
 }
 

--- a/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/possible_non_array_or_object_array_key_last.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector/Fixture/possible_non_array_or_object_array_key_last.php.inc
@@ -36,6 +36,7 @@ class PossibleNonArrayOrObjectArrayKeyLast
         }
 
         if (!\is_array($v) || 1 !== \count($v) || 10 !== \strlen($k = (string) key($v)) || "\x9D" !== $k[0] || "\0" !== $k[5] || "\x5F" !== $k[9]) {
+            reset($v);
             return false;
         }
 

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
@@ -221,10 +221,7 @@ CODE_SAMPLE
         }
 
         if ($stmt instanceof StmtsAwareInterface) {
-            $stmt->stmts = array_merge(
-                [$resetExpression],
-                $stmt->stmts
-            );
+            $stmt->stmts = array_merge([$resetExpression], $stmt->stmts);
         }
 
         return $newStmts;

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
@@ -214,6 +214,10 @@ CODE_SAMPLE
 
         $newStmts[] = $stmt;
 
+        if (! $stmt instanceof StmtsAwareInterface && ! $stmt instanceof Return_) {
+            $newStmts[] = new Expression($this->nodeFactory->createFuncCall('reset', [$array]));
+        }
+
         return $newStmts;
     }
 

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeArrayKeyFirstLastRector.php
@@ -214,8 +214,17 @@ CODE_SAMPLE
 
         $newStmts[] = $stmt;
 
+        $resetExpression = new Expression($this->nodeFactory->createFuncCall('reset', [$array]));
+
         if (! $stmt instanceof StmtsAwareInterface && ! $stmt instanceof Return_) {
             $newStmts[] = new Expression($this->nodeFactory->createFuncCall('reset', [$array]));
+        }
+
+        if ($stmt instanceof StmtsAwareInterface) {
+            $stmt->stmts = array_merge(
+                [$resetExpression],
+                $stmt->stmts
+            );
         }
 
         return $newStmts;


### PR DESCRIPTION
@kapersoft @TomasVotruba here the proper solution to fix https://github.com/rectorphp/rector/issues/8531


