### PR TITLE
[DowngradePhp81] Handle abstract method on DowngradeNewInInitializerRector

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector/Fixture/in_abstract_method.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector/Fixture/in_abstract_method.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector\Fixture;
+
+interface MyInterface {
+    public function myMethod(\stdClass $my_instance = new \stdClass());
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNewInInitializerRector\Fixture;
+
+interface MyInterface {
+    public function myMethod(\stdClass $my_instance = null);
+}
+
+?>

--- a/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
+++ b/rules/DowngradePhp81/Rector/FunctionLike/DowngradeNewInInitializerRector.php
@@ -180,6 +180,10 @@ CODE_SAMPLE
             $param->default = $this->nodeFactory->createNull();
         }
 
+        if ($functionLike->stmts === null) {
+            return $functionLike;
+        }
+
         $functionLike->stmts ??= [];
         $functionLike->stmts = array_merge($stmts, $functionLike->stmts);
 


### PR DESCRIPTION
For usage of interface method, yes, all interface method are abstract, it should not append stmts, only change param.

Fixes https://github.com/rectorphp/rector/issues/8810