### PR TITLE
Add fixture test for skip internal php php-parser token on DowngradePhpTokenRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/StaticCall/DowngradePhpTokenRector/Fixture/skip_extends_internal_php_parser_token.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/StaticCall/DowngradePhpTokenRector/Fixture/skip_extends_internal_php_parser_token.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\StaticCall\DowngradePhpTokenRector\Fixture;
+
+class SkipExtendsInternalPhpParserToken extends \PhpParser\Internal\TokenPolyfill
+{
+    public function run()
+    {
+        return $this->text;
+    }
+
+    public function run2()
+    {
+        $self = new self();
+        return $self->text;
+    }
+}


### PR DESCRIPTION
Add test fixture for patch:

- https://github.com/rectorphp/rector-downgrade-php/pull/239
- https://github.com/rectorphp/rector-downgrade-php/pull/240