### PR TITLE
Avoid using ->isArray()->yes() usage on getKeyType() usage next

### DIFF
--- a/rules/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector.php
+++ b/rules/DowngradePhp81/Rector/Array_/DowngradeArraySpreadStringKeyRector.php
@@ -11,8 +11,6 @@ use PHPStan\Analyser\MutatingScope;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\IntegerType;
-use PHPStan\Type\IntersectionType;
-use PHPStan\Type\UnionType;
 use Rector\DowngradePhp81\NodeAnalyzer\ArraySpreadAnalyzer;
 use Rector\DowngradePhp81\NodeFactory\ArrayMergeFromArraySpreadFactory;
 use Rector\PHPStan\ScopeFetcher;
@@ -92,19 +90,10 @@ CODE_SAMPLE
             }
 
             $type = $this->nodeTypeResolver->getType($item->value);
-            if (! $type->isArray()->yes()) {
+            if (! $type instanceof ArrayType && ! $type instanceof ConstantArrayType) {
                 continue;
             }
 
-            if ($type instanceof UnionType) {
-                continue;
-            }
-
-            if ($type instanceof IntersectionType) {
-                continue;
-            }
-
-            /** @var ArrayType|ConstantArrayType $type */
             $keyType = $type->getKeyType();
             if ($keyType instanceof IntegerType) {
                 return true;


### PR DESCRIPTION
To avoid crash like in 

- https://github.com/rectorphp/rector/issues/8907