### PR TITLE
[DowngradePhp80] Skip native AllowDynamicProperties attribute on DowngradeAttributeToAnnotationRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/reprint_same_line.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/reprint_same_line.php.inc
@@ -17,7 +17,7 @@ namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotati
 use AllowDynamicProperties;
 
 #[AllowDynamicProperties]
-class User
+class ReprintSameLine
 {
 }
 

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/reprint_same_line.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/reprint_same_line.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+use AllowDynamicProperties;
+
+#[AllowDynamicProperties]class ReprintSameLine
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+use AllowDynamicProperties;
+
+#[AllowDynamicProperties]
+class User
+{
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/skip_allow_dynamic_properties.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/skip_allow_dynamic_properties.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+use AllowDynamicProperties;
+
+#[AllowDynamicProperties]
+class User
+{
+}

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -34,7 +34,7 @@ final class DowngradeAttributeToAnnotationRector extends AbstractRector implemen
     /**
      * @var string[]
      */
-    private const SKIPPED_ATTRIBUTES = ['Attribute', 'ReturnTypeWillChange'];
+    private const SKIPPED_ATTRIBUTES = ['Attribute', 'ReturnTypeWillChange', 'AllowDynamicProperties'];
 
     /**
      * @var DowngradeAttributeToAnnotation[]

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -19,6 +19,7 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\DowngradePhp80\ValueObject\DowngradeAttributeToAnnotation;
 use Rector\NodeFactory\DoctrineAnnotationFactory;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -105,9 +106,11 @@ CODE_SAMPLE
         $this->isDowngraded = false;
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        $requireReprint = false;
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $key => $attribute) {
                 if ($this->shouldSkipAttribute($attribute)) {
+                    $requireReprint = true;
                     continue;
                 }
 
@@ -145,6 +148,11 @@ CODE_SAMPLE
         $this->cleanupEmptyAttrGroups($node);
 
         if (! $this->isDowngraded) {
+            if ($requireReprint) {
+                $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+                return $node;
+            }
+
             return null;
         }
 

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -110,6 +110,9 @@ CODE_SAMPLE
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $key => $attribute) {
                 if ($this->shouldSkipAttribute($attribute)) {
+                    // avoid error on same line
+                    // as attribute ->getStartLine() always equal with node ->getStartLine()
+                    // can't validate it, so enforce to reprint later
                     $requireReprint = true;
                     continue;
                 }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8908