### PR TITLE
Remove no longer needed FUNC_ARGS_TRAILING_COMMA attribute usage marker on downgrade rules

### DIFF
--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -91,7 +91,6 @@ CODE_SAMPLE
         }
 
         // remove comma
-        $lastArg->setAttribute(AttributeKey::FUNC_ARGS_TRAILING_COMMA, false);
         $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
 
         return $node;

--- a/rules/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector.php
+++ b/rules/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector.php
@@ -68,7 +68,6 @@ CODE_SAMPLE
             }
 
             // remove comma
-            $last->setAttribute(AttributeKey::FUNC_ARGS_TRAILING_COMMA, false);
             $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
 
             return $node;

--- a/rules/DowngradePhp80/Rector/ClassMethod/DowngradeTrailingCommasInParamUseRector.php
+++ b/rules/DowngradePhp80/Rector/ClassMethod/DowngradeTrailingCommasInParamUseRector.php
@@ -123,7 +123,6 @@ CODE_SAMPLE
         }
 
         $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-        $last->setAttribute(AttributeKey::FUNC_ARGS_TRAILING_COMMA, false);
 
         return $node;
     }


### PR DESCRIPTION
Ref PR:

- https://github.com/rectorphp/rector-src/pull/6491

the orig node set to null already cover it.