### PR TITLE
[DowngradePhp80] Downgrade same line attribute on non-removed attribute on DowngradeAttributeToAnnotationRector

### DIFF
--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -115,7 +115,10 @@ CODE_SAMPLE
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $key => $attribute) {
                 if ($this->shouldSkipAttribute($attribute)) {
-                    if (isset($oldTokens[$attrGroup->getEndTokenPos() + 1]) && ! str_contains((string) $oldTokens[$attrGroup->getEndTokenPos() + 1], "\n")) {
+                    if (isset($oldTokens[$attrGroup->getEndTokenPos() + 1]) && ! str_contains(
+                        (string) $oldTokens[$attrGroup->getEndTokenPos() + 1],
+                        "\n"
+                    )) {
                         $print = $this->betterStandardPrinter->print($attrGroup);
                         $attributesAsComments[] = new Comment($print);
 

--- a/tests/Issues/DowngradeAttributeSameLineWithPromotion/DowngradeAttributeSameLineWithPromotionTest.php
+++ b/tests/Issues/DowngradeAttributeSameLineWithPromotion/DowngradeAttributeSameLineWithPromotionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\DowngradeAttributeSameLineWithPromotion;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeAttributeSameLineWithPromotionTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DowngradeAttributeSameLineWithPromotion/Fixture/fixture.php.inc
+++ b/tests/Issues/DowngradeAttributeSameLineWithPromotion/Fixture/fixture.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\Issues\DowngradeAttributeSameLineWithPromotion\Fixture;
+
+#[\Attribute]final class WithSameLine
+{
+    public function __construct(public string $a)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\DowngradeAttributeSameLineWithPromotion\Fixture;
+
+#[\Attribute]
+final class WithSameLine
+{
+    public string $a;
+    public function __construct(string $a)
+    {
+        $this->a = $a;
+    }
+}
+
+?>

--- a/tests/Issues/DowngradeAttributeSameLineWithPromotion/config/configured_rule.php
+++ b/tests/Issues/DowngradeAttributeSameLineWithPromotion/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
+use Rector\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        DowngradeAttributeToAnnotationRector::class,
+        DowngradePropertyPromotionRector::class
+    ]);
+};

--- a/tests/Issues/DowngradeAttributeSameLineWithPromotion/config/configured_rule.php
+++ b/tests/Issues/DowngradeAttributeSameLineWithPromotion/config/configured_rule.php
@@ -7,8 +7,5 @@ use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
 use Rector\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([
-        DowngradeAttributeToAnnotationRector::class,
-        DowngradePropertyPromotionRector::class
-    ]);
+    $rectorConfig->rules([DowngradeAttributeToAnnotationRector::class, DowngradePropertyPromotionRector::class]);
 };


### PR DESCRIPTION
On php 8.x, `#[\Attribute]final class WithSameLine` is valid code, while on php 7, it got error, so it needs to mark as comment, with get line via token, per recommended at:

- https://github.com/nikic/PHP-Parser/issues/1043#issuecomment-2496130277