### PR TITLE
[Downgradephp80] Better add new line handling with insert \n prefix for same line attribute DowngradeAttributeToAnnotationRector skipped class

### DIFF
--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -119,10 +119,9 @@ CODE_SAMPLE
                         (string) $oldTokens[$attrGroup->getEndTokenPos() + 1],
                         "\n"
                     )) {
-                        $print = $this->betterStandardPrinter->print($attrGroup);
-                        $attributesAsComments[] = new Comment($print);
-
-                        unset($attrGroup->attrs[$key]);
+                        // add new line
+                        $oldTokens[$attrGroup->getEndTokenPos() + 1]->text = "\n" . $oldTokens[$attrGroup->getEndTokenPos() + 1]->text;
+                        $this->isDowngraded = true;
                     }
 
                     continue;
@@ -160,12 +159,6 @@ CODE_SAMPLE
 
         // cleanup empty attr groups
         $this->cleanupEmptyAttrGroups($node);
-
-        if ($attributesAsComments !== []) {
-            $this->isDowngraded = true;
-            $currentComments = $node->getAttribute(AttributeKey::COMMENTS) ?? [];
-            $node->setAttribute(AttributeKey::COMMENTS, array_merge($currentComments, $attributesAsComments));
-        }
 
         if (! $this->isDowngraded) {
             return null;

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\DowngradePhp80\Rector\Class_;
 
-use PhpParser\Comment;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Param;
@@ -20,8 +19,6 @@ use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\DowngradePhp80\ValueObject\DowngradeAttributeToAnnotation;
 use Rector\NodeFactory\DoctrineAnnotationFactory;
-use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -49,8 +46,7 @@ final class DowngradeAttributeToAnnotationRector extends AbstractRector implemen
     public function __construct(
         private readonly DoctrineAnnotationFactory $doctrineAnnotationFactory,
         private readonly DocBlockUpdater $docBlockUpdater,
-        private readonly PhpDocInfoFactory $phpDocInfoFactory,
-        private readonly BetterStandardPrinter $betterStandardPrinter
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 
@@ -109,7 +105,6 @@ CODE_SAMPLE
         $this->isDowngraded = false;
 
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        $attributesAsComments = [];
         $oldTokens = $this->file->getOldTokens();
 
         foreach ($node->attrGroups as $attrGroup) {


### PR DESCRIPTION
continue of 

- https://github.com/rectorphp/rector-downgrade-php/pull/251

It seems add new line no token next is better for it, so it keep attribute, but new lined.