### PR TITLE
[DowngradePhp84] Add DowngradeNewMethodCallWithoutParenthesesRector

### DIFF
--- a/config/set/downgrade-php84.php
+++ b/config/set/downgrade-php84.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp84\Rector\MethodCall\DowngradeNewMethodCallWithoutParenthesesRector;
+use Rector\ValueObject\PhpVersion;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->phpVersion(PhpVersion::PHP_83);
+    $rectorConfig->rules([
+        DowngradeNewMethodCallWithoutParenthesesRector::class,
+    ]);
+};

--- a/config/set/level/down-to-php83.php
+++ b/config/set/level/down-to-php83.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\DowngradeLevelSetList;
 use Rector\Set\ValueObject\DowngradeSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([DowngradeLevelSetList::DOWN_TO_PHP_83, DowngradeSetList::PHP_83]);
+    $rectorConfig->sets([DowngradeSetList::PHP_84]);
 };

--- a/rules-tests/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector/DowngradeNewMethodCallWithoutParenthesesRectorTest.php
+++ b/rules-tests/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector/DowngradeNewMethodCallWithoutParenthesesRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp84\Rector\MethodCall\DowngradeNewMethodCallWithoutParenthesesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeNewMethodCallWithoutParenthesesRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp84\Rector\MethodCall\DowngradeNewMethodCallWithoutParenthesesRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        new Request()->withMethod('GET')->withUri('/hello-world');
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp84\Rector\MethodCall\DowngradeNewMethodCallWithoutParenthesesRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        (new Request())->withMethod('GET')->withUri('/hello-world');
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector/Fixture/skip_already_parentheses.php.inc
+++ b/rules-tests/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector/Fixture/skip_already_parentheses.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp84\Rector\MethodCall\DowngradeNewMethodCallWithoutParenthesesRector\Fixture;
+
+final class SkipAlreadyParentheses
+{
+    public function run()
+    {
+        (new Request())->withMethod('GET')->withUri('/hello-world');
+    }
+}

--- a/rules-tests/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp84\Rector\MethodCall\DowngradeNewMethodCallWithoutParenthesesRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DowngradeNewMethodCallWithoutParenthesesRector::class);
+};

--- a/rules/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector.php
+++ b/rules/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp84\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/new_without_parentheses
+ *
+ * @see \Rector\Tests\DowngradePhp84\Rector\MethodCall\DowngradeNewMethodCallWithoutParenthesesRector\DowngradeNewMethodCallWithoutParenthesesRectorTest
+ */
+final class DowngradeNewMethodCallWithoutParenthesesRector extends AbstractRector
+{
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add parentheses on new method call without parentheses',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+new Request()->withMethod('GET')->withUri('/hello-world');
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+(new Request())->withMethod('GET')->withUri('/hello-world');
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->var instanceof New_) {
+            return null;
+        }
+
+        $oldTokens = $this->file->getOldTokens();
+        if (isset($oldTokens[$node->getStartTokenPos()]) && (string) $oldTokens[$node->getStartTokenPos()] === '(') {
+            return null;
+        }
+
+        $node->var->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        return $node;
+    }
+}

--- a/src/Set/ValueObject/DowngradeLevelSetList.php
+++ b/src/Set/ValueObject/DowngradeLevelSetList.php
@@ -13,6 +13,11 @@ final class DowngradeLevelSetList
     /**
      * @var string
      */
+    public const DOWN_TO_PHP_83 = __DIR__ . '/../../../config/set/level/down-to-php83.php';
+
+    /**
+     * @var string
+     */
     public const DOWN_TO_PHP_82 = __DIR__ . '/../../../config/set/level/down-to-php82.php';
 
     /**

--- a/src/Set/ValueObject/DowngradeSetList.php
+++ b/src/Set/ValueObject/DowngradeSetList.php
@@ -44,4 +44,9 @@ final class DowngradeSetList
      * @var string
      */
     public const PHP_83 = __DIR__ . '/../../../config/set/downgrade-php83.php';
+
+    /**
+     * @var string
+     */
+    public const PHP_84 = __DIR__ . '/../../../config/set/downgrade-php84.php';
 }


### PR DESCRIPTION
To downgrade new method call without parentheses for php 8.4 https://wiki.php.net/rfc/new_without_parentheses

Ref to allow feature https://github.com/rectorphp/rector/issues/8701, the downgrade rule need to exists on the first place.