### PR TITLE
Remove trailing comma by token instead of set origNode to null

### DIFF
--- a/rules-tests/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector/Fixture/fixture.php.inc
@@ -27,7 +27,10 @@ class Fixture
     {
         $a = '';
         unset($a, $b);
-        unset($c, $d);
+        unset(
+            $c,
+            $d
+        );
     }
 }
 

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use Rector\DowngradePhp73\Tokenizer\FollowedByCommaAnalyzer;
+use Rector\DowngradePhp73\Tokenizer\TrailingCommaRemover;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -20,7 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class DowngradeTrailingCommasInFunctionCallsRector extends AbstractRector
 {
     public function __construct(
-        private readonly FollowedByCommaAnalyzer $followedByCommaAnalyzer
+        private readonly FollowedByCommaAnalyzer $followedByCommaAnalyzer,
+        private readonly TrailingCommaRemover $trailingCommaRemover
     ) {
     }
 
@@ -89,22 +91,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $tokens = $this->file->getOldTokens();
-        $iteration = 1;
-
-        while (isset($tokens[$args[$lastArgKey]->getEndTokenPos() + $iteration])) {
-            if (trim($tokens[$args[$lastArgKey]->getEndTokenPos() + $iteration]->text) === '') {
-                ++$iteration;
-                continue;
-            }
-
-            if (trim($tokens[$args[$lastArgKey]->getEndTokenPos() + $iteration]->text) !== ',') {
-                break;
-            }
-
-            $tokens[$args[$lastArgKey]->getEndTokenPos() + $iteration]->text = '';
-            break;
-        }
+        $this->trailingCommaRemover->remove($this->file, $lastArg);
 
         return $node;
     }

--- a/rules/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector.php
+++ b/rules/DowngradePhp73/Rector/Unset_/DowngradeTrailingCommasInUnsetRector.php
@@ -7,7 +7,7 @@ namespace Rector\DowngradePhp73\Rector\Unset_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Unset_;
 use Rector\DowngradePhp73\Tokenizer\FollowedByCommaAnalyzer;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\DowngradePhp73\Tokenizer\TrailingCommaRemover;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -18,7 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class DowngradeTrailingCommasInUnsetRector extends AbstractRector
 {
     public function __construct(
-        private readonly FollowedByCommaAnalyzer $followedByCommaAnalyzer
+        private readonly FollowedByCommaAnalyzer $followedByCommaAnalyzer,
+        private readonly TrailingCommaRemover $trailingCommaRemover
     ) {
     }
 
@@ -67,8 +68,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            // remove comma
-            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            $this->trailingCommaRemover->remove($this->file, $last);
 
             return $node;
         }

--- a/rules/DowngradePhp73/Tokenizer/TrailingCommaRemover.php
+++ b/rules/DowngradePhp73/Tokenizer/TrailingCommaRemover.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp73\Tokenizer;
+
+use PhpParser\Node;
+use Rector\ValueObject\Application\File;
+
+final class TrailingCommaRemover
+{
+    public function remove(File $file, Node $node): void
+    {
+        $tokens = $file->getOldTokens();
+        $iteration = 1;
+
+        while (isset($tokens[$node->getEndTokenPos() + $iteration])) {
+            if (trim($tokens[$node->getEndTokenPos() + $iteration]->text) === '') {
+                ++$iteration;
+                continue;
+            }
+
+            if (trim($tokens[$node->getEndTokenPos() + $iteration]->text) !== ',') {
+                break;
+            }
+
+            $tokens[$node->getEndTokenPos() + $iteration]->text = '';
+            break;
+        }
+    }
+}

--- a/rules/DowngradePhp80/Rector/ClassMethod/DowngradeTrailingCommasInParamUseRector.php
+++ b/rules/DowngradePhp80/Rector/ClassMethod/DowngradeTrailingCommasInParamUseRector.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\DowngradePhp73\Tokenizer\FollowedByCommaAnalyzer;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\DowngradePhp73\Tokenizer\TrailingCommaRemover;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,7 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class DowngradeTrailingCommasInParamUseRector extends AbstractRector
 {
     public function __construct(
-        private readonly FollowedByCommaAnalyzer $followedByCommaAnalyzer
+        private readonly FollowedByCommaAnalyzer $followedByCommaAnalyzer,
+        private readonly TrailingCommaRemover $trailingCommaRemover
     ) {
     }
 
@@ -122,7 +123,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        $this->trailingCommaRemover->remove($this->file, $last);
 
         return $node;
     }

--- a/rules/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector.php
+++ b/rules/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector.php
@@ -7,7 +7,6 @@ namespace Rector\DowngradePhp84\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -59,7 +58,9 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->var->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+        $oldTokens[$node->var->getStartTokenPos()]->text = '(' . $oldTokens[$node->var->getStartTokenPos()];
+        $oldTokens[$node->var->getEndTokenPos()]->text .= ')';
+
         return $node;
     }
 }

--- a/rules/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector.php
+++ b/rules/DowngradePhp84/Rector/MethodCall/DowngradeNewMethodCallWithoutParenthesesRector.php
@@ -54,7 +54,14 @@ CODE_SAMPLE
         }
 
         $oldTokens = $this->file->getOldTokens();
-        if (isset($oldTokens[$node->getStartTokenPos()]) && (string) $oldTokens[$node->getStartTokenPos()] === '(') {
+        $startTokenPos = $node->getStartTokenPos();
+        $endTokenPos = $node->getEndTokenPos();
+
+        if (! isset($oldTokens[$startTokenPos], $oldTokens[$endTokenPos])) {
+            return null;
+        }
+
+        if ((string) $oldTokens[$node->getStartTokenPos()] === '(') {
             return null;
         }
 


### PR DESCRIPTION
To avoid issue like in `DowngradeFlexibleHeredocSyntaxRector` when combined like in:

- https://github.com/rectorphp/rector-downgrade-php/pull/256
- https://github.com/rectorphp/rector-downgrade-php/pull/257
- https://github.com/rectorphp/rector-downgrade-php/pull/258

but for function call and unset, so avoid reprint when possible.