### PR TITLE
[DowngradePhp82] Add DowngradeIteratorCountToArrayRector

### DIFF
--- a/config/set/downgrade-php82.php
+++ b/config/set/downgrade-php82.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\ValueObject\PhpVersion;
 use Rector\DowngradePhp82\Rector\Class_\DowngradeReadonlyClassRector;
+use Rector\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector;
 use Rector\DowngradePhp82\Rector\FunctionLike\DowngradeStandaloneNullTrueFalseReturnTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(PhpVersion::PHP_81);
     $rectorConfig->rules([
         DowngradeReadonlyClassRector::class,
-        DowngradeStandaloneNullTrueFalseReturnTypeRector::class
+        DowngradeStandaloneNullTrueFalseReturnTypeRector::class,
+        DowngradeIteratorCountToArrayRector::class,
     ]);
 };

--- a/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/DowngradeIteratorCountToArrayRectorTest.php
+++ b/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/DowngradeIteratorCountToArrayRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeIteratorCountToArrayRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/Fixture/possible_not_traversable.php.inc
+++ b/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/Fixture/possible_not_traversable.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector\Fixture;
+
+final class PossibleNotTraversable
+{
+    function test(array|\Traversable $data) {
+        $c = iterator_count($data);
+        $v = iterator_to_array($data);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector\Fixture;
+
+final class PossibleNotTraversable
+{
+    function test(array|\Traversable $data) {
+        $c = iterator_count(is_array($data) ? new \ArrayIterator($data) : $data);
+        $v = iterator_to_array(is_array($data) ? new \ArrayIterator($data) : $data);
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/Fixture/skip_already_has_object_type.php.inc
+++ b/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/Fixture/skip_already_has_object_type.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector\Fixture;
+
+final class SkipAlreadyHasObjectType
+{
+    function test(array|\Traversable $data) {
+        $c = iterator_count(is_array($data) ? new \ArrayIterator($data) : $data);
+        $v = iterator_to_array(is_array($data) ? new \ArrayIterator($data) : $data);
+    }
+}

--- a/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/Fixture/skip_already_traversable.php.inc
+++ b/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/Fixture/skip_already_traversable.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector\Fixture;
+
+final class SkipAlreadyTraversable
+{
+    function test(\Traversable $data)
+    {
+        $c = iterator_count($data);
+        $v = iterator_to_array($data);
+    }
+}

--- a/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DowngradeIteratorCountToArrayRector::class);
+};

--- a/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
+++ b/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
@@ -113,6 +113,7 @@ CODE_SAMPLE
         }
 
         // already has object type check
-        return $type->isObject()->yes();
+        return $type->isObject()
+            ->yes();
     }
 }

--- a/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
+++ b/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp82\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use Rector\NodeAnalyzer\ArgsAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://www.php.net/manual/en/migration82.other-changes.php#migration82.other-changes.functions.spl
+ *
+ * @see \Rector\Tests\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector\DowngradeIteratorCountToArrayRectorTest
+ * @see https://3v4l.org/TPW7a#v8.1.31
+ */
+final class DowngradeIteratorCountToArrayRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ArgsAnalyzer $argsAnalyzer
+    ) {
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Ensure pass Traversable instance before use in iterator_count() and iterator_to_array()',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+function test(array|Traversable $data) {
+    $c = iterator_count($data);
+    $v = iterator_to_array($data);
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+function test(array|Traversable $data) {
+    $c = iterator_count(is_array($data) ? new ArrayIterator($data) : $data);
+    $v = iterator_to_array(is_array($data) ? new ArrayIterator($data) : $data);
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isNames($node, ['iterator_count', 'iterator_to_array'])) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+        if ($this->argsAnalyzer->hasNamedArg($args)) {
+            return null;
+        }
+
+        if (! isset($args[0])) {
+            return null;
+        }
+
+        $type = $this->nodeTypeResolver->getType($args[0]->value);
+        if ($this->shouldSkip($type, $args[0]->value)) {
+            return null;
+        }
+
+        $firstValue = $node->args[0]->value;
+        $node->args[0]->value = new Ternary(
+            $this->nodeFactory->createFuncCall('is_array', [new Arg($firstValue)]),
+            new New_(new FullyQualified('ArrayIterator'), [new Arg($firstValue)]),
+            $firstValue
+        );
+
+        return $node;
+    }
+
+    private function shouldSkip(Type $type, Expr $expr): bool
+    {
+        // only array type
+        if ($type->isArray()->yes()) {
+            return false;
+        }
+
+        if ($type instanceof UnionType) {
+            // possibly already transformed
+            return $expr instanceof Ternary;
+        }
+
+        // already has object type check
+        return $type->isObject()->yes();
+    }
+}

--- a/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
+++ b/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
@@ -6,13 +6,11 @@ namespace Rector\DowngradePhp82\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Type\Type;
-use PHPStan\Type\UnionType;
 use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -87,7 +85,7 @@ CODE_SAMPLE
         }
 
         $type = $this->nodeTypeResolver->getType($args[0]->value);
-        if ($this->shouldSkip($type, $args[0]->value)) {
+        if ($this->shouldSkip($type)) {
             return null;
         }
 
@@ -103,19 +101,12 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function shouldSkip(Type $type, Expr $expr): bool
+    private function shouldSkip(Type $type): bool
     {
-        // only array type
         if ($type->isArray()->yes()) {
             return false;
         }
 
-        if ($type instanceof UnionType) {
-            // possibly already transformed
-            return $expr instanceof Ternary;
-        }
-
-        // already has object type check
         return $type->isObject()
             ->yes();
     }

--- a/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
+++ b/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
@@ -17,6 +17,7 @@ use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 /**
  * @changelog https://www.php.net/manual/en/migration82.other-changes.php#migration82.other-changes.functions.spl
@@ -89,6 +90,8 @@ CODE_SAMPLE
         if ($this->shouldSkip($type, $args[0]->value)) {
             return null;
         }
+
+        Assert::isInstanceOf($node->args[0], Arg::class);
 
         $firstValue = $node->args[0]->value;
         $node->args[0]->value = new Ternary(


### PR DESCRIPTION
see https://www.php.net/manual/en/migration82.other-changes.php#migration82.other-changes.functions.spl

see https://3v4l.org/TPW7a#v8.1.31 on php 8.1, parameter only accept Traversable, so array needs to be converted to `ArrayIterator` first, see see https://3v4l.org/YAeZD#v8.1.31