### PR TITLE
Fix for Match to Switch when inside binary operation

### DIFF
--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -323,7 +323,7 @@ CODE_SAMPLE
     {
         $newExpr = clone $expr;
         // remove the match statement from the binary operation
-        $this->traverseNodesWithCallable($newExpr, function (Node $node) use ($body): ?Node\Expr {
+        $this->traverseNodesWithCallable($newExpr, static function (Node $node) use ($body): ?Node\Expr {
             if ($node instanceof Match_) {
                 return $body;
             }

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -7,8 +7,10 @@ namespace Rector\DowngradePhp80\Rector\Expression;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Match_;
@@ -294,7 +296,7 @@ CODE_SAMPLE
         } elseif ($matchArm->body instanceof Throw_) {
             $stmts[] = new Expression($matchArm->body);
         } elseif ($node instanceof Return_) {
-            if ($node->expr instanceof Node\Expr\BinaryOp) {
+            if ($node->expr instanceof BinaryOp) {
                 $stmts[] = $this->replicateBinaryOp($node->expr, $matchArm->body);
             } else {
                 $stmts[] = new Return_($matchArm->body);
@@ -319,13 +321,13 @@ CODE_SAMPLE
         return $stmts;
     }
 
-    private function replicateBinaryOp(Node\Expr\BinaryOp $expr, Node\Expr $body): Return_
+    private function replicateBinaryOp(BinaryOp $binaryOp, Expr $expr): Return_
     {
-        $newExpr = clone $expr;
+        $newExpr = clone $binaryOp;
         // remove the match statement from the binary operation
-        $this->traverseNodesWithCallable($newExpr, static function (Node $node) use ($body): ?Node\Expr {
+        $this->traverseNodesWithCallable($newExpr, static function (Node $node) use ($expr): ?Expr {
             if ($node instanceof Match_) {
-                return $body;
+                return $expr;
             }
 
             return null;

--- a/tests/Set/Fixture/match_in_binary_op.php.inc
+++ b/tests/Set/Fixture/match_in_binary_op.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Set\Fixture;
 
-final class MatchBoolean
+final class MatchInBinaryOp
 {
     public function run($value, $booleanFlag)
     {
@@ -10,6 +10,14 @@ final class MatchBoolean
             $value === 2 => true,
             default => false,
         } && $booleanFlag;
+    }
+
+    public function runTwo($value, $booleanFlag)
+    {
+        return match (true) {
+                $value === 2 => true,
+                default => false,
+        } || $booleanFlag;
     }
 }
 
@@ -19,7 +27,7 @@ final class MatchBoolean
 
 namespace Rector\Tests\Set\Fixture;
 
-final class MatchBoolean
+final class MatchInBinaryOp
 {
     public function run($value, $booleanFlag)
     {
@@ -28,6 +36,16 @@ final class MatchBoolean
                 return true && $booleanFlag;
             default:
                 return false && $booleanFlag;
+        }
+    }
+
+    public function runTwo($value, $booleanFlag)
+    {
+        switch (true) {
+            case $value === 2:
+                return true || $booleanFlag;
+            default:
+                return false || $booleanFlag;
         }
     }
 }

--- a/tests/Set/Fixture/match_maintains_return_condition.php.inc
+++ b/tests/Set/Fixture/match_maintains_return_condition.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Set\Fixture;
+
+final class MatchBoolean
+{
+    public function run($value, $booleanFlag)
+    {
+        return match (true) {
+            $value === 2 => true,
+            default => false,
+        } && $booleanFlag;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Set\Fixture;
+
+final class MatchBoolean
+{
+    public function run($value, $booleanFlag)
+    {
+        switch (true) {
+            case $value === 2:
+                return true && $booleanFlag;
+            default:
+                return false && $booleanFlag;
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
# Changes

- adds a new fixture for the switch to match statement rule in the downgrade to PHP 7.2 test
- adds changes to the `DowngradeMatchToSwitchRector` rule.

# Why

Currently this rule breaks code where the match statement exists within a binary operation. For example:

```php
public function run($value, $booleanFlag)
{
    return match (true) {
        $value === 2 => true,
        default => false,
    } && $booleanFlag;
}
```

would become

```php
public function run($value, $booleanFlag)
{
    switch (true) {
        case $value === 2:
            return true;
        default:
            return false;
    }
}
```

This would cause conditions related to the return statement to be lost. [This happened in the Rector Laravel project](https://github.com/driftingly/rector-laravel/issues/287). For now I've just separated the match statement and the binary op, but it would be nice to fix this either way.

This change fixes that by allowing the rest of the return statement to be retained with the case's return statement.

```php
public function run($value, $booleanFlag)
    {
        switch (true) {
            case $value === 2:
                return true && $booleanFlag;
            default:
                return false && $booleanFlag;
        }
    }
```