### PR TITLE
Check for variable name in parameters before adding to uses

### DIFF
--- a/rules-tests/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector/Fixture/no_params_duplicated_in_use.php.inc
+++ b/rules-tests/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector/Fixture/no_params_duplicated_in_use.php.inc
@@ -1,0 +1,89 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector\Fixture;
+
+class NoParamsDuplicatedInUse
+{
+    public function single()
+    {
+        $callable = fn($param) => $param;
+    }
+
+    public function singleArrayAssignment()
+    {
+        $callable = fn($param) => $arr[] = $param;
+    }
+
+    public function multiple()
+    {
+        $callable = fn($param, $param2) => $param + $param2;
+    }
+
+    public function multipleArrayAssignment()
+    {
+        $callable = fn($param, $param2) => $arr[] = $param + $param2;
+    }
+
+    public function mixed()
+    {
+        $callable = fn($param) => $param + $param2;
+    }
+
+    public function mixedArrayAssignment()
+    {
+        $callable = fn($param) => $arr[] = $param + $param2;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector\Fixture;
+
+class NoParamsDuplicatedInUse
+{
+    public function single()
+    {
+        $callable = function ($param) {
+            return $param;
+        };
+    }
+
+    public function singleArrayAssignment()
+    {
+        $callable = function ($param) use ($arr) {
+            return $arr[] = $param;
+        };
+    }
+
+    public function multiple()
+    {
+        $callable = function ($param, $param2) {
+            return $param + $param2;
+        };
+    }
+
+    public function multipleArrayAssignment()
+    {
+        $callable = function ($param, $param2) use ($arr) {
+            return $arr[] = $param + $param2;
+        };
+    }
+
+    public function mixed()
+    {
+        $callable = function ($param) use ($param2) {
+            return $param + $param2;
+        };
+    }
+
+    public function mixedArrayAssignment()
+    {
+        $callable = function ($param) use ($arr, $param2) {
+            return $arr[] = $param + $param2;
+        };
+    }
+}
+
+?>

--- a/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
+++ b/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
@@ -98,7 +98,16 @@ CODE_SAMPLE
             );
 
             if (! $isFound) {
-                $anonymousFunctionFactory->uses[] = new ClosureUse($node->expr->expr);
+                $isAlsoParam = in_array(
+                    $node->expr->expr->name,
+                    array_map(function($param) {
+                        return $param->var->name;
+                    }, $node->params)
+                );
+
+                if (! $isAlsoParam) {
+                    $anonymousFunctionFactory->uses[] = new ClosureUse($node->expr->expr);
+                }
             }
         }
 

--- a/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
+++ b/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
@@ -100,7 +100,10 @@ CODE_SAMPLE
             if (! $isFound) {
                 $isAlsoParam = in_array(
                     $node->expr->expr->name,
-                    array_map(static fn ($param) => $param->var instanceof Variable ? $param->var->name : null, $node->params)
+                    array_map(
+                        static fn ($param) => $param->var instanceof Variable ? $param->var->name : null,
+                        $node->params
+                    )
                 );
 
                 if (! $isAlsoParam) {

--- a/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
+++ b/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
                 $isAlsoParam = in_array(
                     $node->expr->expr->name,
                     array_map(function($param) {
-                        return $param->var->name;
+                        return $param->var instanceof Variable ? $param->var->name : null;
                     }, $node->params)
                 );
 

--- a/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
+++ b/rules/DowngradePhp74/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
@@ -100,9 +100,7 @@ CODE_SAMPLE
             if (! $isFound) {
                 $isAlsoParam = in_array(
                     $node->expr->expr->name,
-                    array_map(function($param) {
-                        return $param->var instanceof Variable ? $param->var->name : null;
-                    }, $node->params)
+                    array_map(static fn ($param) => $param->var instanceof Variable ? $param->var->name : null, $node->params)
                 );
 
                 if (! $isAlsoParam) {


### PR DESCRIPTION
I hit an issue today in downgrading some Laravel code.  
The `ArrowFunctionToAnonymousFunctionRector` rule would take this function 

```
fn ($deferred) => app(DeferredCallbackCollection::class)[] = $deferred
```

and transform it to this

```
function ($deferred) use ($deferred) {
    return app(DeferredCallbackCollection::class)[] = $deferred;
}
```

and this would result in a PHP error

> Fatal error: Cannot use lexical variable $deferred as a parameter name in <file_path>

My patch works well for solving my problem but if there's a better way to fix this that would be great too.
Thanks for your hard work!