### PR TITLE
Fix rules that were applied even if no actual change was made

### DIFF
--- a/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
+++ b/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
@@ -67,7 +67,7 @@ CODE_SAMPLE
     /**
      * @param ConstFetch|BitwiseOr|If_ $node
      */
-    public function refactor(Node $node): Expr|If_|null
+    public function refactor(Node $node): Expr|null
     {
         if ($node instanceof If_) {
             $this->markConstantKnownInInnerStmts($node);

--- a/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
+++ b/rules/DowngradePhp72/Rector/ConstFetch/DowngradePhp72JsonConstRector.php
@@ -70,7 +70,8 @@ CODE_SAMPLE
     public function refactor(Node $node): Expr|If_|null
     {
         if ($node instanceof If_) {
-            return $this->refactorIf($node);
+            $this->markConstantKnownInInnerStmts($node);
+            return null;
         }
 
         // skip as known
@@ -84,20 +85,18 @@ CODE_SAMPLE
         ]);
     }
 
-    private function refactorIf(If_ $if): ?If_
+    private function markConstantKnownInInnerStmts(If_ $if): void
     {
         if (! $this->defineFuncCallAnalyzer->isDefinedWithConstants($if->cond, [
             JsonConstant::INVALID_UTF8_IGNORE,
             JsonConstant::INVALID_UTF8_SUBSTITUTE,
         ])) {
-            return null;
+            return;
         }
 
         $this->traverseNodesWithCallable($if, static function (Node $node): null {
             $node->setAttribute(self::PHP72_JSON_CONSTANT_IS_KNOWN, true);
             return null;
         });
-
-        return $if;
     }
 }

--- a/rules/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector.php
+++ b/rules/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector.php
@@ -102,9 +102,9 @@ CODE_SAMPLE
 
     /**
      * @param ConstFetch|BitwiseOr|If_|TryCatch|Expression $node
-     * @return null|Expr|If_|array<Expression|If_>
+     * @return null|Expr|array<Expression|If_>
      */
-    public function refactor(Node $node): null|Expr|If_|array
+    public function refactor(Node $node): null|Expr|array
     {
         if ($node instanceof If_) {
             $this->markConstantKnownInInnerStmts($node);

--- a/rules/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector.php
+++ b/rules/DowngradePhp73/Rector/ConstFetch/DowngradePhp73JsonConstRector.php
@@ -107,7 +107,8 @@ CODE_SAMPLE
     public function refactor(Node $node): null|Expr|If_|array
     {
         if ($node instanceof If_) {
-            return $this->refactorIf($node);
+            $this->markConstantKnownInInnerStmts($node);
+            return null;
         }
 
         // skip as known
@@ -146,18 +147,16 @@ CODE_SAMPLE
         return $this->jsonConstCleaner->clean($node, [JsonConstant::THROW_ON_ERROR]);
     }
 
-    private function refactorIf(If_ $if): ?If_
+    private function markConstantKnownInInnerStmts(If_ $if): void
     {
         if (! $this->defineFuncCallAnalyzer->isDefinedWithConstants($if->cond, [JsonConstant::THROW_ON_ERROR])) {
-            return null;
+            return;
         }
 
         $this->traverseNodesWithCallable($if, static function (Node $node): null {
             $node->setAttribute(self::PHP73_JSON_CONSTANT_IS_KNOWN, true);
             return null;
         });
-
-        return $if;
     }
 
     private function resolveFuncCall(Expression $Expression): ?FuncCall

--- a/rules/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector.php
+++ b/rules/DowngradePhp74/Rector/MethodCall/DowngradeReflectionGetTypeRector.php
@@ -77,11 +77,13 @@ CODE_SAMPLE
     public function refactor(Node $node): Node|null
     {
         if ($node instanceof Instanceof_) {
-            return $this->refactorInstanceof($node);
+            $this->markSkipInstanceof($node);
+            return null;
         }
 
         if ($node instanceof Ternary) {
-            return $this->refactorTernary($node);
+            $this->markSkipTernary($node);
+            return null;
         }
 
         if ($node->getAttribute(self::SKIP_NODE) === true) {
@@ -105,36 +107,34 @@ CODE_SAMPLE
         );
     }
 
-    private function refactorInstanceof(Instanceof_ $instanceof): ?Instanceof_
+    private function markSkipInstanceof(Instanceof_ $instanceof): void
     {
         if (! $this->isName($instanceof->class, 'ReflectionNamedType')) {
-            return null;
+            return;
         }
 
         if (! $instanceof->expr instanceof MethodCall) {
-            return null;
+            return;
         }
 
         // checked typed → safe
         $instanceof->expr->setAttribute(self::SKIP_NODE, true);
-        return $instanceof;
     }
 
-    private function refactorTernary(Ternary $ternary): ?Ternary
+    private function markSkipTernary(Ternary $ternary): void
     {
         if (! $ternary->if instanceof Expr) {
-            return null;
+            return;
         }
 
         if (! $ternary->cond instanceof FuncCall) {
-            return null;
+            return;
         }
 
         if (! $this->isName($ternary->cond, 'method_exists')) {
-            return null;
+            return;
         }
 
         $ternary->if->setAttribute(self::SKIP_NODE, true);
-        return $ternary;
     }
 }


### PR DESCRIPTION
In all three cases, the problem existed because some functions did not actually change nodes in a way that would result in a code change, they just added attributes to inner statements or expressions so that other functions could work on the code, but they still returned a node value as though it had been changed. I modified this so that these functions did not return a node. I also changed their name as they were called `refactorXXX` and no refactor was actually done in these functions, so I used what I think are more appropriate names