### PR TITLE
[DowngradePhp83] Add DowngradeReadonlyAnonymousClassRector

### DIFF
--- a/config/set/downgrade-php83.php
+++ b/config/set/downgrade-php83.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\DowngradePhp83\Rector\Class_\DowngradeReadonlyAnonymousClassRector;
 use Rector\ValueObject\PhpVersion;
 use Rector\DowngradePhp83\Rector\ClassConst\DowngradeTypedClassConstRector;
 
@@ -10,5 +11,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(PhpVersion::PHP_82);
     $rectorConfig->rules([
         DowngradeTypedClassConstRector::class,
+        DowngradeReadonlyAnonymousClassRector::class,
     ]);
 };

--- a/rules-tests/DowngradePhp82/Rector/Class_/DowngradeReadonlyClassRector/Fixture/skip_anonymous_class.php.inc
+++ b/rules-tests/DowngradePhp82/Rector/Class_/DowngradeReadonlyClassRector/Fixture/skip_anonymous_class.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp82\Rector\Class_\DowngradeReadonlyClassRector\Fixture;
+
+final class SkipAnonymousClass
+{
+    public function run()
+    {
+        new readonly class {
+            public string $foo = 'bar';
+        };
+    }
+}

--- a/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/DowngradeReadonlyAnonymousClassRectorTest.php
+++ b/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/DowngradeReadonlyAnonymousClassRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp83\Rector\Class_\DowngradeReadonlyAnonymousClassRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeReadonlyAnonymousClassRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp83\Rector\Class_\DowngradeReadonlyAnonymousClassRector\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        new readonly class {
+            public string $foo = 'bar';
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp83\Rector\Class_\DowngradeReadonlyAnonymousClassRector\Fixture;
+
+final class Fixture
+{
+    public function run()
+    {
+        new class {
+            public readonly string $foo = 'bar';
+        };
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/Fixture/skip_named_class.php.inc
+++ b/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/Fixture/skip_named_class.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp83\Rector\Class_\DowngradeReadonlyAnonymousClassRector\Fixture;
+
+final readonly class SkipNamedClass
+{
+    public string $foo;
+}
+

--- a/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/Fixture/with_parentheses.php.inc
+++ b/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/Fixture/with_parentheses.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp83\Rector\Class_\DowngradeReadonlyAnonymousClassRector\Fixture;
+
+final class WithParentheses
+{
+    public function run()
+    {
+        (new readonly class {
+            public string $foo = 'bar';
+        });
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp83\Rector\Class_\DowngradeReadonlyAnonymousClassRector\Fixture;
+
+final class WithParentheses
+{
+    public function run()
+    {
+        (new class {
+            public readonly string $foo = 'bar';
+        });
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp83\Rector\Class_\DowngradeReadonlyAnonymousClassRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DowngradeReadonlyAnonymousClassRector::class);
+};

--- a/rules/DowngradePhp82/NodeManipulator/DowngradeReadonlyClassManipulator.php
+++ b/rules/DowngradePhp82/NodeManipulator/DowngradeReadonlyClassManipulator.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp82\NodeManipulator;
+
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Rector\ValueObject\MethodName;
+
+final readonly class DowngradeReadonlyClassManipulator
+{
+    public function __construct(
+        private VisibilityManipulator $visibilityManipulator
+    ) {
+
+    }
+
+    public function process(Class_ $class): ?Class_
+    {
+        if (! $this->visibilityManipulator->isReadonly($class)) {
+            return null;
+        }
+
+        $this->visibilityManipulator->removeReadonly($class);
+        $this->makePropertiesReadonly($class);
+        $this->makePromotedPropertiesReadonly($class);
+
+        return $class;
+    }
+
+    private function makePropertiesReadonly(Class_ $class): void
+    {
+        foreach ($class->getProperties() as $property) {
+            if ($property->isReadonly()) {
+                continue;
+            }
+
+            /**
+             * It technically impossible that readonly class has:
+             *
+             *  - non-typed property
+             *  - static property
+             *
+             * but here to ensure no flip-flop when using direct rule for multiple rules applied
+             */
+            if ($property->type === null) {
+                continue;
+            }
+
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $this->visibilityManipulator->makeReadonly($property);
+        }
+    }
+
+    private function makePromotedPropertiesReadonly(Class_ $class): void
+    {
+        $classMethod = $class->getMethod(MethodName::CONSTRUCT);
+        if (! $classMethod instanceof ClassMethod) {
+            return;
+        }
+
+        foreach ($classMethod->getParams() as $param) {
+            if ($this->visibilityManipulator->isReadonly($param)) {
+                continue;
+            }
+
+            /**
+             * not property promotion, just param
+             */
+            if ($param->flags === 0) {
+                continue;
+            }
+
+            /**
+             * also not typed, just param
+             */
+            if ($param->type === null) {
+                continue;
+            }
+
+            $this->visibilityManipulator->makeReadonly($param);
+        }
+    }
+}

--- a/rules/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector.php
+++ b/rules/DowngradePhp83/Rector/Class_/DowngradeReadonlyAnonymousClassRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\DowngradePhp82\Rector\Class_;
+namespace Rector\DowngradePhp83\Rector\Class_;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
@@ -12,11 +12,10 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @changelog https://wiki.php.net/rfc/readonly_classes
- *
- * @see \Rector\Tests\DowngradePhp82\Rector\Class_\DowngradeReadonlyClassRector\DowngradeReadonlyClassRectorTest
+ * @see https://www.php.net/manual/en/migration83.new-features.php#migration83.new-features.core.readonly-modifier-improvements
+ * @see \Rector\Tests\DowngradePhp83\Rector\Class_\DowngradeReadonlyAnonymousClassRector\DowngradeReadonlyAnonymousClassRectorTest
  */
-final class DowngradeReadonlyClassRector extends AbstractRector
+final class DowngradeReadonlyAnonymousClassRector extends AbstractRector
 {
     public function __construct(
         private readonly DowngradeReadonlyClassManipulator $downgradeReadonlyClassManipulator
@@ -34,11 +33,11 @@ final class DowngradeReadonlyClassRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Remove "readonly" class type, decorate all properties to "readonly"',
+            'Remove "readonly" class type on anonymous class, decorate all properties to "readonly"',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
-final readonly class SomeClass
+new readonly class
 {
     public string $foo;
 
@@ -46,11 +45,11 @@ final readonly class SomeClass
     {
         $this->foo = 'foo';
     }
-}
+};
 CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
-final class SomeClass
+new class
 {
     public readonly string $foo;
 
@@ -70,7 +69,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if ($node->isAnonymous()) {
+        if (! $node->isAnonymous()) {
             return null;
         }
 


### PR DESCRIPTION
Ref issue and PR:

- https://github.com/rectorphp/rector/issues/9151
- https://github.com/rectorphp/rector-src/pull/6916

This share logic between DowngradePhp82 `DowngradeReadonlyClassRector`, which moved the logic to: `DowngradeReadonlyClassManipulator` service, with anonymous check for both rules so can run by rule:

- Php82 `DowngradeReadonlyClassRector`: skip anonymous, downgrade normal class
- Php83 `DowngradeReadonlyAnonymousClassRector`: skip normal class, downgrade anonymous class.