### PR TITLE
[DowngradePhp80/Php73] Handle comma removed on combination DowngradeNamedArgumentRector + DowngradeTrailingCommasInFunctionCallsRector

### DIFF
--- a/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
@@ -56,7 +56,7 @@ final readonly class NamedToUnnamedArgs
                     $currentArg->value,
                     $currentArg->byRef,
                     $currentArg->unpack,
-                    $currentArg->getAttributes(),
+                    [],
                     null
                 );
             }

--- a/rules/DowngradePhp80/NodeAnalyzer/UnnamedArgumentResolver.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/UnnamedArgumentResolver.php
@@ -45,7 +45,7 @@ final readonly class UnnamedArgumentResolver
 
         foreach ($currentArgs as $key => $arg) {
             if (! $arg->name instanceof Identifier) {
-                $unnamedArgs[$key] = new Arg($arg->value, $arg->byRef, $arg->unpack, $arg->getAttributes(), null);
+                $unnamedArgs[$key] = new Arg($arg->value, $arg->byRef, $arg->unpack, [], null);
 
                 continue;
             }

--- a/tests/Issues/DowngradeNamedTrailing/DowngradeNamedTrailingTest.php
+++ b/tests/Issues/DowngradeNamedTrailing/DowngradeNamedTrailingTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Issues\DowngradeNamedTrailing;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeNamedTrailingTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Issues/DowngradeNamedTrailing/Fixture/fixture.php.inc
+++ b/tests/Issues/DowngradeNamedTrailing/Fixture/fixture.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Tests\Issues\DowngradeNamedTrailing\Fixture;
+
+class Fixture
+{
+    public function __construct(
+        protected string $type,
+        array $data = [],
+        protected ?string $id = null,
+        protected ?int $version = null,
+        protected ?string $key = null,
+        protected ?string $internalId = null,
+        protected ?string $externalId = null,
+    ) {
+        $this->setData($data);
+    }
+}
+
+$contents = new Fixture(
+    $content->getType(),
+    id: $content->getId(),
+    data: ['error' => $e->getMessage()]
+);
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Issues\DowngradeNamedTrailing\Fixture;
+
+class Fixture
+{
+    public function __construct(
+        protected string $type,
+        array $data = [],
+        protected ?string $id = null,
+        protected ?int $version = null,
+        protected ?string $key = null,
+        protected ?string $internalId = null,
+        protected ?string $externalId = null,
+    ) {
+        $this->setData($data);
+    }
+}
+
+$contents = new Fixture(
+    $content->getType(),
+    ['error' => $e->getMessage()],
+    $content->getId()
+);
+
+?>

--- a/tests/Issues/DowngradeNamedTrailing/config/configured_rule.php
+++ b/tests/Issues/DowngradeNamedTrailing/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp80\Rector\MethodCall\DowngradeNamedArgumentRector;
+use Rector\DowngradePhp73\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector;
+
+return RectorConfig::configure()
+    ->withRules([
+        DowngradeNamedArgumentRector::class,
+        DowngradeTrailingCommasInFunctionCallsRector::class,
+    ]);

--- a/tests/Issues/DowngradeNamedTrailing/config/configured_rule.php
+++ b/tests/Issues/DowngradeNamedTrailing/config/configured_rule.php
@@ -1,11 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 use Rector\Config\RectorConfig;
-use Rector\DowngradePhp80\Rector\MethodCall\DowngradeNamedArgumentRector;
 use Rector\DowngradePhp73\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector;
+use Rector\DowngradePhp80\Rector\MethodCall\DowngradeNamedArgumentRector;
 
 return RectorConfig::configure()
-    ->withRules([
-        DowngradeNamedArgumentRector::class,
-        DowngradeTrailingCommasInFunctionCallsRector::class,
-    ]);
+    ->withRules([DowngradeNamedArgumentRector::class, DowngradeTrailingCommasInFunctionCallsRector::class]);


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9187
Ref https://getrector.com/demo/dd085b66-d609-4add-b44c-d4eb8072a3e5