### PR TITLE
[DowngradePhp80] Handle on trait on DowngradePropertyPromotionRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/on_trait.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector/Fixture/on_trait.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+trait OnTrait
+{
+    public function __construct(public float $value = 0.0)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradePropertyPromotionRector\Fixture;
+
+trait OnTrait
+{
+    public float $value = 0.0;
+    public function __construct(float $value = 0.0)
+    {
+        $this->value = $value;
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradePropertyPromotionRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Trait_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
@@ -75,11 +76,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Class_::class];
+        return [Class_::class, Trait_::class];
     }
 
     /**
-     * @param Class_ $node
+     * @param Class_|Trait_ $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -163,7 +164,7 @@ CODE_SAMPLE
     private function resolvePropertiesFromPromotedParams(
         ClassMethod $classMethod,
         array $promotedParams,
-        Class_ $class
+        Class_|Trait_ $class
     ): array {
         $properties = $this->createPropertiesFromParams($classMethod, $promotedParams);
         $class->stmts = array_merge($properties, $class->stmts);
@@ -177,7 +178,7 @@ CODE_SAMPLE
      */
     private function addPropertyAssignsToConstructorClassMethod(
         array $properties,
-        Class_ $class,
+        Class_|Trait_ $class,
         array $oldComments
     ): void {
         $assigns = [];


### PR DESCRIPTION
This is to cover property promotion on trait, that used on `symfony/service-contracts` 3.6.0

https://github.com/rectorphp/rector-src/actions/runs/15243096830/job/42865604088#step:14:72

Ref https://github.com/symfony/service-contracts/blob/f021b05a130d35510bd6b25fe9053c2a8a15d5d4/ServiceLocatorTrait.php#L27-L36