### PR TITLE
[DowngradePhp73] Real patch for previous node token just swapped with trailing comma and named argument

### DIFF
--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use Rector\DowngradePhp73\Tokenizer\FollowedByCommaAnalyzer;
 use Rector\DowngradePhp73\Tokenizer\TrailingCommaRemover;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;

--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -85,16 +85,6 @@ CODE_SAMPLE
             return null;
         }
 
-        // reprint is needed as position changed that can't rely on token position
-        // @see https://github.com/rectorphp/rector-downgrade-php/pull/281
-        // @see https://github.com/rectorphp/rector-downgrade-php/pull/285
-        foreach ($args as $arg) {
-            if ($arg->getEndTokenPos() < 0) {
-                $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-                return $node;
-            }
-        }
-
         $lastArgKey = count($args) - 1;
 
         $lastArg = $args[$lastArgKey];
@@ -102,7 +92,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->trailingCommaRemover->remove($this->file, $lastArg);
+        $previousArg = $args[$lastArgKey - 1] ?? null;
+        $this->trailingCommaRemover->remove($this->file, $lastArg, $previousArg);
 
         return $node;
     }

--- a/rules/DowngradePhp73/Tokenizer/TrailingCommaRemover.php
+++ b/rules/DowngradePhp73/Tokenizer/TrailingCommaRemover.php
@@ -9,7 +9,7 @@ use Rector\ValueObject\Application\File;
 
 final class TrailingCommaRemover
 {
-    public function remove(File $file, Node $node): void
+    public function remove(File $file, Node $node, ?Node $previousNode = null): void
     {
         $tokens = $file->getOldTokens();
         $iteration = 1;
@@ -21,6 +21,12 @@ final class TrailingCommaRemover
             }
 
             if (trim($tokens[$node->getEndTokenPos() + $iteration]->text) !== ',') {
+                break;
+            }
+
+            // position just swapped
+            if ($previousNode instanceof Node && $previousNode->getEndTokenPos() > $node->getEndTokenPos()) {
+                $this->remove($file, $previousNode);
                 break;
             }
 

--- a/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
@@ -52,13 +52,8 @@ final readonly class NamedToUnnamedArgs
                     continue;
                 }
 
-                $unnamedArgs[$paramPosition] = new Arg(
-                    $currentArg->value,
-                    $currentArg->byRef,
-                    $currentArg->unpack,
-                    [],
-                    null
-                );
+                $currentArg->name = null;
+                $unnamedArgs[$paramPosition] = $currentArg;
             }
         }
 

--- a/rules/DowngradePhp80/NodeAnalyzer/UnnamedArgumentResolver.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/UnnamedArgumentResolver.php
@@ -45,7 +45,7 @@ final readonly class UnnamedArgumentResolver
 
         foreach ($currentArgs as $key => $arg) {
             if (! $arg->name instanceof Identifier) {
-                $unnamedArgs[$key] = new Arg($arg->value, $arg->byRef, $arg->unpack, [], null);
+                $unnamedArgs[$key] = $arg;
 
                 continue;
             }

--- a/tests/Issues/DowngradeNamedTrailing/Fixture/fixture.php.inc
+++ b/tests/Issues/DowngradeNamedTrailing/Fixture/fixture.php.inc
@@ -44,6 +44,10 @@ class Fixture
     }
 }
 
-$contents = new Fixture($content->getType(), ['error' => $e->getMessage()], $content->getId());
+$contents = new Fixture(
+    $content->getType(),
+    ['error' => $e->getMessage()],
+    $content->getId()
+);
 
 ?>

--- a/tests/Set/Fixture/named_argument_trailing_comma2.php.inc
+++ b/tests/Set/Fixture/named_argument_trailing_comma2.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Set\Fixture;
 
-final class NamedArgumentTrailingComma
+final class NamedArgumentTrailingComma2
 {
 	public function run(string $foo, string $bar)
     {}
@@ -10,8 +10,8 @@ final class NamedArgumentTrailingComma
     public function execute()
     {
         $this->run(
-            foo: 'foo',
             bar: 'bar',
+            foo: 'foo',
         );
     }
 }
@@ -22,7 +22,7 @@ final class NamedArgumentTrailingComma
 
 namespace Rector\Tests\Set\Fixture;
 
-final class NamedArgumentTrailingComma
+final class NamedArgumentTrailingComma2
 {
 	public function run(string $foo, string $bar)
     {}

--- a/tests/Set/Fixture/named_argument_trailing_comma3.php.inc
+++ b/tests/Set/Fixture/named_argument_trailing_comma3.php.inc
@@ -25,7 +25,7 @@ namespace Rector\Tests\Set\Fixture;
 
 final class NamedArgumentTrailingComma3
 {
-	public function run(string $foo, string $bar)
+	public function run(string $foo, string $bar, string $baz)
     {}
 
     public function execute()

--- a/tests/Set/Fixture/named_argument_trailing_comma3.php.inc
+++ b/tests/Set/Fixture/named_argument_trailing_comma3.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Tests\Set\Fixture;
+
+final class NamedArgumentTrailingComma3
+{
+	public function run(string $foo, string $bar, string $baz)
+    {}
+
+    public function execute()
+    {
+        $this->run(
+            bar: 'bar',
+            baz: 'baz',
+            foo: 'foo',
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Set\Fixture;
+
+final class NamedArgumentTrailingComma3
+{
+	public function run(string $foo, string $bar)
+    {}
+
+    public function execute()
+    {
+        $this->run(
+            'foo',
+            'bar',
+            'baz'
+        );
+    }
+}
+
+?>


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-downgrade-php/pull/285

@iNem0o this is real patch, it doesn't need to reprint, so position not changed.