### PR TITLE
[DowngradePhp73] Real patch for previous node token just swapped with trailing comma and named argument (take 2)

### DIFF
--- a/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/DowngradePhp73/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -85,13 +85,14 @@ CODE_SAMPLE
             return null;
         }
 
-        // reprint is needed as position changed that can't rely on token position
-        // @see https://github.com/rectorphp/rector-downgrade-php/pull/281
-        // @see https://github.com/rectorphp/rector-downgrade-php/pull/285
         foreach ($args as $arg) {
+            // reprinted, needs to remove from call like itself
             if ($arg->getEndTokenPos() < 0) {
-                $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-                return $node;
+                $hasChanged = $this->trailingCommaRemover->removeFromCallLike($this->file, $node);
+
+                if ($hasChanged) {
+                    return $node;
+                }
             }
         }
 

--- a/rules/DowngradePhp73/Tokenizer/TrailingCommaRemover.php
+++ b/rules/DowngradePhp73/Tokenizer/TrailingCommaRemover.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp73\Tokenizer;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\CallLike;
 use Rector\ValueObject\Application\File;
 
 final class TrailingCommaRemover
@@ -27,5 +28,30 @@ final class TrailingCommaRemover
             $tokens[$node->getEndTokenPos() + $iteration]->text = '';
             break;
         }
+    }
+
+    public function removeFromCallLike(File $file, CallLike $node): bool
+    {
+        $tokens = $file->getOldTokens();
+        $iteration = 1;
+
+        $hasChanged = false;
+        while (isset($tokens[$node->getEndTokenPos() - $iteration])) {
+            $text = trim($tokens[$node->getEndTokenPos() - $iteration]->text);
+
+            if (in_array($text, [')', ''], true)) {
+                ++$iteration;
+                continue;
+            }
+
+            if ($text === ',') {
+                $tokens[$node->getEndTokenPos() - $iteration]->text = '';
+                $hasChanged = true;
+            }
+
+            break;
+        }
+
+        return $hasChanged;
     }
 }

--- a/tests/Issues/DowngradeNamedTrailing/Fixture/fixture.php.inc
+++ b/tests/Issues/DowngradeNamedTrailing/Fixture/fixture.php.inc
@@ -44,6 +44,10 @@ class Fixture
     }
 }
 
-$contents = new Fixture($content->getType(), ['error' => $e->getMessage()], $content->getId());
+$contents = new Fixture(
+    $content->getType(),
+    ['error' => $e->getMessage()],
+    $content->getId()
+);
 
 ?>

--- a/tests/Set/Fixture/named_argument_trailing_comma.php.inc
+++ b/tests/Set/Fixture/named_argument_trailing_comma.php.inc
@@ -29,7 +29,10 @@ final class NamedArgumentTrailingComma
 
     public function execute()
     {
-        $this->run('foo', 'bar');
+        $this->run(
+            'foo',
+            'bar'
+        );
     }
 }
 

--- a/tests/Set/Fixture/named_argument_trailing_comma2.php.inc
+++ b/tests/Set/Fixture/named_argument_trailing_comma2.php.inc
@@ -29,7 +29,10 @@ final class NamedArgumentTrailingComma2
 
     public function execute()
     {
-        $this->run('foo', 'bar');
+        $this->run(
+            'foo',
+            'bar'
+        );
     }
 }
 

--- a/tests/Set/Fixture/named_argument_trailing_comma3.php.inc
+++ b/tests/Set/Fixture/named_argument_trailing_comma3.php.inc
@@ -30,7 +30,11 @@ final class NamedArgumentTrailingComma3
 
     public function execute()
     {
-        $this->run('foo', 'bar', 'baz');
+        $this->run(
+            'foo',
+            'bar',
+            'baz'
+        );
     }
 }
 

--- a/tests/Set/Fixture/named_argument_trailing_comma4.php.inc
+++ b/tests/Set/Fixture/named_argument_trailing_comma4.php.inc
@@ -30,7 +30,11 @@ final class NamedArgumentTrailingComma4
 
     public function execute()
     {
-        $this->run('foo', 'bar', 'baz');
+        $this->run(
+            'foo',
+            'bar',
+            'baz'
+        );
     }
 }
 


### PR DESCRIPTION
Continue of PR:

- https://github.com/rectorphp/rector-downgrade-php/pull/285

@iNem0o this is real patch part 2, it utilize the `CallLike` last token itself, lookup previous token until found `,` after `)` and `''`.