### PR TITLE
Add support for unknown types in DowngradeNamedArgumentRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/MethodCall/DowngradeNamedArgumentRector/Fixture/remove_from_unknown_type.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/MethodCall/DowngradeNamedArgumentRector/Fixture/remove_from_unknown_type.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\MethodCall\DowngradeNamedArgumentRector\Fixture;
+
+final class RemoveFromUnknownType
+{
+    function someMethod($container, $abstract, $parameters ) {
+        return $container->resolve($abstract, $parameters, raiseEvents: \true);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\MethodCall\DowngradeNamedArgumentRector\Fixture;
+
+final class RemoveFromUnknownType
+{
+    function someMethod($container, $abstract, $parameters ) {
+        return $container->resolve($abstract, $parameters, \true);
+    }
+}
+
+?>


### PR DESCRIPTION
Sometimes the named args is used on a variable without any type, like in latest illuminate/contaienr 12.18.x

See https://github.com/illuminate/container/commit/ff9dde2c8dce16ea9ecf0418095749311240aff9

![Screenshot From 2025-06-24 21-36-23](https://github.com/user-attachments/assets/56e28262-6579-4a07-a5e7-6b7e498b4ab8)





In that case, we cannot leak this named variable further. All we can do is to take a guess, that value is used on the right location and remove it :+1: 