### PR TITLE
[DowngradePhp81] Add PHP_VERSION_ID < 80100 check on DowngradeSetAccessibleReflectionPropertyRector

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/on_reflection_method.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/on_reflection_method.php.inc
@@ -22,7 +22,9 @@ class OnReflectionMethod
     public function run($object)
     {
         $reflectionMethod = new \ReflectionMethod($object, 'bar');
-        $reflectionMethod->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionMethod->setAccessible(true);
+        }
         return $reflectionMethod->__invoke($object, []);
     }
 }

--- a/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/on_return.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/on_return.php.inc
@@ -21,7 +21,9 @@ class OnReturn
     public function run($object)
     {
         $reflection = new \ReflectionMethod($object, 'bar');
-        $reflection->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflection->setAccessible(true);
+        }
         return $reflection;
     }
 }

--- a/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/skip_already_if_php_version.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/skip_already_if_php_version.php.inc
@@ -2,23 +2,7 @@
 
 namespace Rector\Tests\DowngradePhp81\Rector\StmtsAwareInterface\DowngradeSetAccessibleReflectionPropertyRector\Fixture;
 
-class SomeClass
-{
-    public function run($object)
-    {
-        $reflectionProperty = new \ReflectionProperty($object, 'bar');
-
-        return $reflectionProperty->getValue($object);
-    }
-}
-
-?>
------
-<?php
-
-namespace Rector\Tests\DowngradePhp81\Rector\StmtsAwareInterface\DowngradeSetAccessibleReflectionPropertyRector\Fixture;
-
-class SomeClass
+final class SkipAlreadyIfPhpVersion
 {
     public function run($object)
     {
@@ -30,5 +14,3 @@ class SomeClass
         return $reflectionProperty->getValue($object);
     }
 }
-
-?>

--- a/rules/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector.php
+++ b/rules/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector.php
@@ -7,11 +7,16 @@ namespace Rector\DowngradePhp81\Rector\StmtsAwareInterface;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BinaryOp\Smaller;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use Rector\Contract\PhpParser\Node\StmtsAwareInterface;
 use Rector\Naming\Naming\VariableNaming;
@@ -57,7 +62,9 @@ class SomeClass
     public function run($object)
     {
         $reflectionProperty = new ReflectionProperty($object, 'bar');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         return $reflectionProperty->getValue($object);
     }
@@ -126,6 +133,10 @@ CODE_SAMPLE
                     continue;
                 }
 
+                if ($this->isSetAccessibleIfMethodCall($nextStmt)) {
+                    continue;
+                }
+
                 array_splice($node->stmts, $key + 1, 0, [$this->createSetAccessibleExpression($variable)]);
             } else {
                 $previousStmts = [
@@ -147,12 +158,17 @@ CODE_SAMPLE
         return null;
     }
 
-    private function createSetAccessibleExpression(Expr $expr): Expression
+    private function createSetAccessibleExpression(Expr $expr): If_
     {
         $args = [$this->nodeFactory->createArg($this->nodeFactory->createTrue())];
-
         $setAccessibleMethodCall = $this->nodeFactory->createMethodCall($expr, 'setAccessible', $args);
-        return new Expression($setAccessibleMethodCall);
+
+        return new If_(
+            new Smaller(new ConstFetch(new Name('PHP_VERSION_ID')), new Int_(80100)),
+            [
+                'stmts' => [new Expression($setAccessibleMethodCall)],
+            ]
+        );
     }
 
     private function isSetAccessibleMethodCall(?Stmt $stmt): bool
@@ -168,5 +184,30 @@ CODE_SAMPLE
         $methodCall = $stmt->expr;
 
         return $this->isName($methodCall->name, 'setAccessible');
+    }
+
+    private function isSetAccessibleIfMethodCall(?Stmt $stmt): bool
+    {
+        if (! $stmt instanceof If_) {
+            return false;
+        }
+
+        if (! $stmt->cond instanceof Smaller) {
+            return false;
+        }
+
+        if (! $stmt->cond->left instanceof ConstFetch && ! $this->isName($stmt->cond->left->name, 'PHP_VERSION_ID')) {
+            return false;
+        }
+
+        if (! $stmt->cond->right instanceof Int_ && $stmt->cond->right->value !== 80100) {
+            return false;
+        }
+
+        if (count($stmt->stmts) !== 1) {
+            return false;
+        }
+
+        return $this->isSetAccessibleMethodCall($stmt->stmts[0]);
     }
 }


### PR DESCRIPTION
To avoid deprecated warning on php 8.5

Fixes https://github.com/rectorphp/rector-downgrade-php/issues/305