### PR TITLE
[DowngradePhp81] Skip check php version with ternary on DowngradeHashAlgorithmXxHashRector (part 1)

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_check_phpversion_ternary.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_check_phpversion_ternary.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeHashAlgorithmXxHash\Fixture;
+
+final class SkipCheckPHPVersionTernary
+{
+    public function run($value)
+    {
+        return PHP_VERSION_ID >= 80100
+            ? hash( 'xxh128', $value )
+            : hash( 'md4', $value );
+    }
+}

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
@@ -9,8 +9,10 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
+use PHPStan\Type\IntegerRangeType;
 use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -108,7 +110,20 @@ CODE_SAMPLE
             return true;
         }
 
-        return ! $this->isName($funcCall, 'hash');
+        if (! $this->isName($funcCall, 'hash')) {
+            return true;
+        }
+
+        $scope = ScopeFetcher::fetch($funcCall);
+        $type = $scope->getPhpVersion()
+            ->getType();
+
+        if (! $type instanceof IntegerRangeType) {
+            // next todo: check version_compare() and if() usage
+            return false;
+        }
+
+        return $type->getMin() === 80100;
     }
 
     /**


### PR DESCRIPTION
@kkmuffme this is for check by ternary, that supported by PHPStan via:

```php
        $scope = ScopeFetcher::fetch($funcCall);
        $type = $scope->getPhpVersion()
            ->getType();

        if (! $type instanceof IntegerRangeType) {
            // next todo: check version_compare() and if() usage
            return false;
        }

        return $type->getMin() === 80100;
```

**TODO for next PRs:**

- check `version_compare()`
- check `if()` usage

Ref https://github.com/rectorphp/rector/issues/9327