### PR TITLE
  [DowngradePhp81] Skip check version_compare with ternary on DowngradeHashAlgorithmXxHashRector (part 2)

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_check_version_compare_ternary.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_check_version_compare_ternary.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeHashAlgorithmXxHash\Fixture;
+
+final class SkipCheckVersionCompareTernary
+{
+    public function run_v()
+    {
+        return version_compare(PHP_VERSION, '8.1','>=')
+            ? hash( 'xxh128', $value )
+            : hash( 'md4', $value );
+    }
+}

--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_check_version_compare_ternary2.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_check_version_compare_ternary2.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeHashAlgorithmXxHash\Fixture;
+
+final class SkipCheckVersionCompareTernary2
+{
+    public function run_v()
+    {
+        return version_compare(PHP_VERSION, '8.1','<')
+            ? hash( 'md4', $value )
+            : hash( 'xxh128', $value );
+    }
+}


### PR DESCRIPTION
@kkmuffme this continue of PR:

- https://github.com/rectorphp/rector-downgrade-php/pull/307

to handle `version_compare` in ternary.

**TODO for next PR:**

- check `if()` usage

Ref https://github.com/rectorphp/rector/issues/9327