### PR TITLE
[DowngradePhp81] Skip check version_compare with if on DowngradeHashAlgorithmXxHashRector (part 3)

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_check_version_compare_on_if.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHash/Fixture/skip_check_version_compare_on_if.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FuncCall\DowngradeHashAlgorithmXxHash\Fixture;
+
+final class SkipCheckVersionCompareOnIf
+{
+    public function run_v()
+    {
+        if ( version_compare( PHP_VERSION, '8.1', '>=' ) ) {
+            return hash( 'xxh128', $value );
+        }
+
+        return hash( 'md4', $value );
+    }
+
+    public function run_v2()
+    {
+        if (version_compare( PHP_VERSION, '8.1', '>=' ) ) {
+            $hash = hash( 'xxh128', $value );
+        } else {
+            $hash = hash( 'md4', $value );
+        }
+
+        return $hash;
+    }
+}

--- a/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
+++ b/rules/DowngradePhp81/Rector/FuncCall/DowngradeHashAlgorithmXxHashRector.php
@@ -7,10 +7,14 @@ namespace Rector\DowngradePhp81\Rector\FuncCall;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\IntegerRangeType;
 use Rector\DeadCode\ConditionResolver;
@@ -80,14 +84,22 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Ternary::class, FuncCall::class];
+        return [If_::class, Ternary::class, FuncCall::class];
     }
 
     /**
-     * @param Ternary|FuncCall $node
+     * @param If_|Ternary|FuncCall $node
      */
     public function refactor(Node $node): null|int|Node
     {
+        if ($node instanceof If_) {
+            if ($this->isVersionCompareIf($node)) {
+                return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+            }
+
+            return null;
+        }
+
         if ($node instanceof Ternary) {
             if ($this->isVersionCompareTernary($node)) {
                 return NodeVisitor::DONT_TRAVERSE_CHILDREN;
@@ -116,6 +128,36 @@ CODE_SAMPLE
         $arg->value = new String_(self::REPLACEMENT_ALGORITHM);
 
         return $node;
+    }
+
+    private function isVersionCompareIf(If_ $if): bool
+    {
+        if ($if->cond instanceof FuncCall) {
+            // per use case reported only
+            if (count($if->stmts) !== 1) {
+                return false;
+            }
+
+            $versionCompare = $this->conditionResolver->resolveFromExpr($if->cond);
+
+            if (! $versionCompare instanceof VersionCompareCondition || $versionCompare->getSecondVersion() !== 80100) {
+                return false;
+            }
+
+            if ($versionCompare->getCompareSign() !== '>=') {
+                return false;
+            }
+
+            if ($if->stmts[0] instanceof Expression && $if->stmts[0]->expr instanceof Assign && $if->stmts[0]->expr->expr instanceof FuncCall) {
+                return $this->isName($if->stmts[0]->expr->expr, 'hash');
+            }
+
+            if ($if->stmts[0] instanceof Return_ && $if->stmts[0]->expr instanceof FuncCall) {
+                return $this->isName($if->stmts[0]->expr, 'hash');
+            }
+        }
+
+        return false;
     }
 
     private function isVersionCompareTernary(Ternary $ternary): bool


### PR DESCRIPTION
@kkmuffme this continue of PR:

- https://github.com/rectorphp/rector-downgrade-php/pull/307

to handle `version_compare` in if.

Fixes https://github.com/rectorphp/rector/issues/9327