### PR TITLE
[DowngradePhp81] Handle parent is void on DowngradeNeverTypeDeclarationRector

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/with_parent_is_void.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Fixture/with_parent_is_void.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Fixture;
+
+use Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Source\SomeParentVoid;
+
+class WithParentIsVoid extends SomeParentVoid
+{
+    public function run(): never
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Fixture;
+
+use Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Source\SomeParentVoid;
+
+class WithParentIsVoid extends SomeParentVoid
+{
+    /**
+     * @return never
+     */
+    public function run(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Source/SomeParentVoid.php
+++ b/rules-tests/DowngradePhp81/Rector/FunctionLike/DowngradeNeverTypeDeclarationRector/Source/SomeParentVoid.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector\Source;
+
+class SomeParentVoid
+{
+    public function run(): void
+    {
+    }
+}


### PR DESCRIPTION
@kkmuffme this should can handle:

- https://github.com/rectorphp/rector/issues/9334

For note, this kind of tweak should not needed actually per se, as child should follow parent, that can easily error if not follow, eg: on native `mixed` with child `never`;

https://3v4l.org/dYEAF

which cannot just converted to `void`

https://3v4l.org/fWSJJ

which make error :)