### PR TITLE
[DowngradePhp80] Register Override and SensitiveParameter to skipped attributes on DowngradeAttributeToAnnotationRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/override_and_sensitive_parameters.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/override_and_sensitive_parameters.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+final class OverrideAndSensitiveParameter extends Foo
+{
+    #[\Override]
+    public function run(#[\SensitiveParameter] bool $param) {
+        if ($this->isTrue($param)) {
+            return 5;
+        }
+
+        return '10';
+    }
+
+    private function isTrue($value) {
+        return $value === true;
+    }
+}
+
+?>
+-----
+<?php
+
+final class OverrideAndSensitiveParameter extends Foo
+{
+    #[\Override]
+    public function run(#[\SensitiveParameter]
+ bool $param) {
+        if ($this->isTrue($param)) {
+            return 5;
+        }
+
+        return '10';
+    }
+
+    private function isTrue($value) {
+        return $value === true;
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -34,7 +34,13 @@ final class DowngradeAttributeToAnnotationRector extends AbstractRector implemen
     /**
      * @var string[]
      */
-    private const SKIPPED_ATTRIBUTES = ['Attribute', 'ReturnTypeWillChange', 'AllowDynamicProperties'];
+    private const SKIPPED_ATTRIBUTES = [
+        'Attribute',
+        'ReturnTypeWillChange',
+        'AllowDynamicProperties',
+        'Override',
+        'SensitiveParameter',
+    ];
 
     /**
      * @var DowngradeAttributeToAnnotation[]


### PR DESCRIPTION
- [x] Register Override and SensitiveParameter to skipped attributes on DowngradeAttributeToAnnotationRector
- [x] If it on single line, it make new lined so it marked as "comments"

```diff
-    public function run(#[\SensitiveParameter] bool $param) {
+    public function run(#[\SensitiveParameter]
+ bool $param) 
``` 

Fixes https://github.com/rectorphp/rector/issues/9355