### PR TITLE
 Re-skip Override and SensitiveParameter 

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/override_and_sensitive_parameters.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/override_and_sensitive_parameters.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+final class OverrideAndSensitiveParameter extends Foo
+{
+    #[\Override]
+    public function run(#[\SensitiveParameter] bool $param) {
+        if ($this->isTrue($param)) {
+            return 5;
+        }
+
+        return '10';
+    }
+
+    private function isTrue($value) {
+        return $value === true;
+    }
+}
+
+?>
+-----
+<?php
+
+final class OverrideAndSensitiveParameter extends Foo
+{
+    #[\Override]
+    public function run(#[\SensitiveParameter]
+ bool $param) {
+        if ($this->isTrue($param)) {
+            return 5;
+        }
+
+        return '10';
+    }
+
+    private function isTrue($value) {
+        return $value === true;
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/override_and_sensitive_parameters.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/override_and_sensitive_parameters.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
 final class OverrideAndSensitiveParameter extends Foo
 {
     #[\Override]
@@ -19,6 +21,9 @@ final class OverrideAndSensitiveParameter extends Foo
 ?>
 -----
 <?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+=
 
 final class OverrideAndSensitiveParameter extends Foo
 {

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/override_and_sensitive_parameters.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/override_and_sensitive_parameters.php.inc
@@ -23,7 +23,8 @@ final class OverrideAndSensitiveParameter extends Foo
 final class OverrideAndSensitiveParameter extends Foo
 {
     #[\Override]
-    public function run(#[\SensitiveParameter]
+    public function run(
+ #[\SensitiveParameter]
  bool $param) {
         if ($this->isTrue($param)) {
             return 5;

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/skip_already_newlined_override_and_sensitive_parameters.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/skip_already_newlined_override_and_sensitive_parameters.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+final class SkipAlreadyNewlinedOverrideAndSensitiveParameters extends Foo
+{
+    #[\Override]
+    public function run(
+        #[\SensitiveParameter]
+        bool $param
+    ) {
+        if ($this->isTrue($param)) {
+            return 5;
+        }
+
+        return '10';
+    }
+
+    private function isTrue($value) {
+        return $value === true;
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/skip_already_newlined_override_and_sensitive_parameters.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/skip_already_newlined_override_and_sensitive_parameters.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
 final class SkipAlreadyNewlinedOverrideAndSensitiveParameters extends Foo
 {
     #[\Override]

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -120,7 +120,17 @@ CODE_SAMPLE
                         (string) $oldTokens[$attrGroup->getEndTokenPos() + 1],
                         "\n"
                     )) {
-                        // add new line
+                        if ($node instanceof Param) {
+                            if (isset($oldTokens[$attrGroup->getStartTokenPos() - 1]) && ! str_contains(
+                                (string) $oldTokens[$attrGroup->getStartTokenPos() - 1],
+                                "\n"
+                            )) {
+                                // add new line before
+                                $oldTokens[$attrGroup->getStartTokenPos() - 1]->text .= "\n ";
+                            }
+                        }
+
+                        // add new line after
                         $oldTokens[$attrGroup->getEndTokenPos() + 1]->text = "\n" . $oldTokens[$attrGroup->getEndTokenPos() + 1]->text;
                         $this->isDowngraded = true;
                     }

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -34,7 +34,13 @@ final class DowngradeAttributeToAnnotationRector extends AbstractRector implemen
     /**
      * @var string[]
      */
-    private const SKIPPED_ATTRIBUTES = ['Attribute', 'ReturnTypeWillChange', 'AllowDynamicProperties'];
+    private const SKIPPED_ATTRIBUTES = [
+        'Attribute',
+        'ReturnTypeWillChange',
+        'AllowDynamicProperties',
+        'Override',
+        'SensitiveParameter',
+    ];
 
     /**
      * @var DowngradeAttributeToAnnotation[]

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -126,7 +126,7 @@ CODE_SAMPLE
                                 "\n"
                             )) {
                                 // add new line before
-                                $oldTokens[$attrGroup->getStartTokenPos() - 1]->text .= "\n ";
+                                $oldTokens[$attrGroup->getStartTokenPos() - 1]->text .= "\n";
                             }
                         }
 

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -120,14 +120,12 @@ CODE_SAMPLE
                         (string) $oldTokens[$attrGroup->getEndTokenPos() + 1],
                         "\n"
                     )) {
-                        if ($node instanceof Param) {
-                            if (isset($oldTokens[$attrGroup->getStartTokenPos() - 1]) && ! str_contains(
-                                (string) $oldTokens[$attrGroup->getStartTokenPos() - 1],
-                                "\n"
-                            )) {
-                                // add new line before
-                                $oldTokens[$attrGroup->getStartTokenPos() - 1]->text .= "\n";
-                            }
+                        if ($node instanceof Param && (isset($oldTokens[$attrGroup->getStartTokenPos() - 1]) && ! str_contains(
+                            (string) $oldTokens[$attrGroup->getStartTokenPos() - 1],
+                            "\n"
+                        ))) {
+                            // add new line before
+                            $oldTokens[$attrGroup->getStartTokenPos() - 1]->text .= "\n";
                         }
 
                         // add new line after


### PR DESCRIPTION
@kkmuffme let's try using reprint instead of token based add new line for this, since downgraded code is applied with php-scoper that may cause param printed in new line again.