### PR TITLE
Avoid reprint whole ClassMethod on DowngradeReadonlyPropertyRector

### DIFF
--- a/rules/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector.php
+++ b/rules/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector.php
@@ -12,7 +12,6 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;

--- a/rules/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector.php
+++ b/rules/DowngradePhp81/Rector/Property/DowngradeReadonlyPropertyRector.php
@@ -102,17 +102,13 @@ CODE_SAMPLE
             return null;
         }
 
-        $hasChangedDoc = false;
         $hasChanged = false;
         foreach ($node->params as $param) {
             if (! $this->visibilityManipulator->isReadonly($param)) {
                 continue;
             }
 
-            if ($this->addPhpDocTag($param)) {
-                $hasChangedDoc = true;
-            }
-
+            $this->addPhpDocTag($param);
             $this->visibilityManipulator->removeReadonly($param);
             $hasChanged = true;
         }
@@ -121,23 +117,18 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($hasChangedDoc) {
-            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-        }
-
         return $node;
     }
 
-    private function addPhpDocTag(Property|Param $node): bool
+    private function addPhpDocTag(Property|Param $node): void
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         if ($phpDocInfo->hasByName(self::TAGNAME)) {
-            return false;
+            return;
         }
 
         $phpDocInfo->addPhpDocTagNode(new PhpDocTagNode('@' . self::TAGNAME, new GenericTagValueNode('')));
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
-        return true;
     }
 }

--- a/rules/DowngradePhp85/Rector/Class_/DowngradeFinalPropertyPromotionRector.php
+++ b/rules/DowngradePhp85/Rector/Class_/DowngradeFinalPropertyPromotionRector.php
@@ -110,16 +110,16 @@ CODE_SAMPLE
         return null;
     }
 
-    private function addPhpDocTag(Property|Param $node): bool
+    private function addPhpDocTag(Property|Param $node): void
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         if ($phpDocInfo->hasByName(self::TAGNAME)) {
-            return false;
+            return;
         }
 
         $phpDocInfo->addPhpDocTagNode(new PhpDocTagNode('@' . self::TAGNAME, new GenericTagValueNode('')));
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
-        return true;
+        return;
     }
 }

--- a/rules/DowngradePhp85/Rector/Class_/DowngradeFinalPropertyPromotionRector.php
+++ b/rules/DowngradePhp85/Rector/Class_/DowngradeFinalPropertyPromotionRector.php
@@ -120,6 +120,5 @@ CODE_SAMPLE
 
         $phpDocInfo->addPhpDocTagNode(new PhpDocTagNode('@' . self::TAGNAME, new GenericTagValueNode('')));
         $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
-        return;
     }
 }

--- a/tests/Issues/DowngradeReadonlyClassPropertyToPhp80/Fixture/fixture.php.inc
+++ b/tests/Issues/DowngradeReadonlyClassPropertyToPhp80/Fixture/fixture.php.inc
@@ -17,12 +17,10 @@ namespace Rector\Tests\Issues\DowngradeReadonlyClassPropertyToPhp80\Fixture;
 
 final class Fixture
 {
-    public function __construct(
-        /**
-         * @readonly
-         */
-        public array $property
-    )
+    public function __construct(/**
+     * @readonly
+     */
+    public array $property)
     {
     }
 }


### PR DESCRIPTION
Reprint may be make it pretty, but got loss the information tokens which may be used by other rules. This is less pretty for print doc under ClassMethod, but safer.

Ref https://github.com/rectorphp/rector-downgrade-php/pull/316#pullrequestreview-3196482242

The better possible solution is to add "new line" on each param when we are going to add docblock, but that will be in separate PR :)