### PR TITLE
[DowngradePhp80] Skip Override attribute on DowngradeAttributeToAnnotationRector

### DIFF
--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/attribute_same_line.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/attribute_same_line.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+#[\Attribute]final class AttributeSameLine
+{
+    #[\ReturnTypeWillChange]
+    public function getValue()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+#[\Attribute]
+final class AttributeSameLine
+{
+    #[\ReturnTypeWillChange]
+    public function getValue()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/with_override.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector/Fixture/with_override.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+final class WithOverride
+{
+    #[\Override]public function action()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector\Fixture;
+
+final class WithOverride
+{
+    #[\Override]
+    public function action()
+    {
+    }
+}
+
+?>

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -34,7 +34,13 @@ final class DowngradeAttributeToAnnotationRector extends AbstractRector implemen
     /**
      * @var string[]
      */
-    private const SKIPPED_ATTRIBUTES = ['Attribute', 'ReturnTypeWillChange', 'AllowDynamicProperties'];
+    private const SKIPPED_ATTRIBUTES = [
+        'Attribute',
+        'ReturnTypeWillChange',
+        'AllowDynamicProperties',
+        'Override',
+        'SensitiveParameter',
+    ];
 
     /**
      * @var DowngradeAttributeToAnnotation[]
@@ -114,8 +120,15 @@ CODE_SAMPLE
                         (string) $oldTokens[$attrGroup->getEndTokenPos() + 1],
                         "\n"
                     )) {
+                        if ($node->getStartTokenPos() === strlen($attribute->name->toString()) - 2) {
+                            $indentation = '';
+                        } else {
+                            $indent = $attrGroup->getEndTokenPos() - $node->getStartTokenPos() + 2;
+                            $indentation = $indent > 0 ? str_repeat(' ', $indent) : '';
+                        }
+
                         // add new line
-                        $oldTokens[$attrGroup->getEndTokenPos() + 1]->text = "\n" . $oldTokens[$attrGroup->getEndTokenPos() + 1]->text;
+                        $oldTokens[$attrGroup->getEndTokenPos() + 1]->text = "\n" . $indentation . $oldTokens[$attrGroup->getEndTokenPos() + 1]->text;
                         $this->isDowngraded = true;
                     }
 


### PR DESCRIPTION
@kkmuffme Let's try this one by one, start with `Override` per use first use case. If it on single line, it enter to new line to mark as comment.