### PR TITLE
Fix deprecated NodeTraverser::DONT_TRAVERSE_CHILDREN

### DIFF
--- a/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
+++ b/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Name\FullyQualified;
-use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;

--- a/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
+++ b/rules/DowngradePhp82/Rector/FuncCall/DowngradeIteratorCountToArrayRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use Rector\NodeAnalyzer\ArgsAnalyzer;
@@ -78,7 +79,7 @@ CODE_SAMPLE
             );
 
             if ($hasIsArrayCheck) {
-                return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                return NodeVisitor::DONT_TRAVERSE_CHILDREN;
             }
 
             return null;


### PR DESCRIPTION
use `NodeVisitor::DONT_TRAVERSE_CHILDREN` instead.