### PR TITLE
Fix phpstan notice on latest phpstan

### DIFF
--- a/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
@@ -141,6 +141,7 @@ CODE_SAMPLE
 
         foreach ($unsafeTypesToMethods as $key => $value) {
             Assert::string($key);
+            Assert::isArray($value);
             Assert::allString($value);
         }
 


### PR DESCRIPTION
noticed on:

https://github.com/rectorphp/rector-src/actions/runs/25209017650/job/73915428002?pr=7975#step:7:15

```
 ------------------------------------------------------------------------
  rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php:147
 ------------------------------------------------------------------------
  - '#Property Rector\\DowngradePhp72\\Rector\\ClassMethod\\DowngradeParameterTypeWideningRector\:\:\$unsafeTypesToMethods \(array<string, array<string>>\) does not accept array<string, iterable<string>>#'
  🪪 assign.propertyType
 ------------------------------------------------------------------------

```