### PR TITLE
[DowngradePhp81] Add AddReturnTypeWillChangeAttributeRector

### DIFF
--- a/config/set/downgrade-php81.php
+++ b/config/set/downgrade-php81.php
@@ -9,6 +9,7 @@ use Rector\DowngradePhp81\Rector\MethodCall\DowngradeIsEnumRector;
 use Rector\Config\RectorConfig;
 use Rector\ValueObject\PhpVersion;
 use Rector\DowngradePhp81\Rector\ClassConst\DowngradeFinalizePublicClassConstantRector;
+use Rector\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector;
 use Rector\DowngradePhp81\Rector\FuncCall\DowngradeArrayIsListRector;
 use Rector\DowngradePhp81\Rector\FuncCall\DowngradeFirstClassCallableSyntaxRector;
 use Rector\DowngradePhp81\Rector\FunctionLike\DowngradeNeverTypeDeclarationRector;
@@ -25,6 +26,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(PhpVersion::PHP_80);
 
     $rectorConfig->rules([
+        AddReturnTypeWillChangeAttributeRector::class,
         DowngradeFinalizePublicClassConstantRector::class,
         DowngradeFirstClassCallableSyntaxRector::class,
         DowngradeNeverTypeDeclarationRector::class,

--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/AddReturnTypeWillChangeAttributeRectorTest.php
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/AddReturnTypeWillChangeAttributeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddReturnTypeWillChangeAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/array_access.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/array_access.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class ArrayAccessClass implements \ArrayAccess
+{
+    public function offsetGet($offset)
+    {
+    }
+
+    public function offsetExists($offset)
+    {
+    }
+
+    public function offsetSet($offset, $value)
+    {
+    }
+
+    public function offsetUnset($offset)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class ArrayAccessClass implements \ArrayAccess
+{
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/countable.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/countable.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeCountable implements \Countable
+{
+    public function count()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeCountable implements \Countable
+{
+    #[\ReturnTypeWillChange]
+    public function count()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/iterator.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/iterator.php.inc
@@ -1,0 +1,62 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeIterator implements \Iterator
+{
+    public function current()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function valid()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeIterator implements \Iterator
+{
+    #[\ReturnTypeWillChange]
+    public function current()
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function key()
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function next()
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function rewind()
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function valid()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/iterator_aggregate.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/iterator_aggregate.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeIteratorAggregate implements \IteratorAggregate
+{
+    public function getIterator()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeIteratorAggregate implements \IteratorAggregate
+{
+    #[\ReturnTypeWillChange]
+    public function getIterator()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/skip_attribute_already_present.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/skip_attribute_already_present.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class ArrayAccessAlreadyAttributed implements \ArrayAccess
+{
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
+    {
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
+    {
+    }
+}

--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/skip_has_return_type.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/skip_has_return_type.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class ArrayAccessWithReturnType implements \ArrayAccess
+{
+    public function offsetGet($offset): mixed
+    {
+    }
+
+    public function offsetExists($offset): bool
+    {
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+    }
+
+    public function offsetUnset($offset): void
+    {
+    }
+}

--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/stringable.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/stringable.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeStringable implements \Stringable
+{
+    public function __toString()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeStringable implements \Stringable
+{
+    #[\ReturnTypeWillChange]
+    public function __toString()
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(AddReturnTypeWillChangeAttributeRector::class);
+};

--- a/rules/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector.php
+++ b/rules/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp81\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://php.watch/versions/8.1/ReturnTypeWillChange
+ *
+ * @see \Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\AddReturnTypeWillChangeAttributeRectorTest
+ */
+final class AddReturnTypeWillChangeAttributeRector extends AbstractRector
+{
+    /**
+     * @var array<string, string[]>
+     *
+     * PHP 8.1 added provisional return types to these core interface methods.
+     * Implementations without matching return types trigger deprecation notices
+     * on PHP 8.1+. Adding #[\ReturnTypeWillChange] suppresses those notices,
+     * keeping the code compatible with older PHP versions simultaneously.
+     */
+    private const array INTERFACE_METHOD_MAP = [
+        'ArrayAccess' => ['offsetGet', 'offsetExists', 'offsetSet', 'offsetUnset'],
+        'Countable' => ['count'],
+        'Iterator' => ['current', 'key', 'next', 'rewind', 'valid'],
+        'IteratorAggregate' => ['getIterator'],
+        'Stringable' => ['__toString'],
+    ];
+
+    private const string RETURN_TYPE_WILL_CHANGE = 'ReturnTypeWillChange';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add #[\ReturnTypeWillChange] attribute to methods implementing PHP 8.1 interface methods with provisional return types, to suppress deprecation notices when running on PHP 8.1+ without the required return types',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass implements \ArrayAccess
+{
+    public function offsetGet($offset)
+    {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass implements \ArrayAccess
+{
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $className = $this->getName($node);
+        if ($className === null) {
+            return null;
+        }
+
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        $hasChanged = false;
+
+        foreach ($node->getMethods() as $classMethod) {
+            if ($this->hasReturnTypeWillChangeAttribute($classMethod)) {
+                continue;
+            }
+
+            if ($classMethod->returnType instanceof Node) {
+                continue;
+            }
+
+            $methodName = $this->getName($classMethod);
+
+            foreach (self::INTERFACE_METHOD_MAP as $interface => $methods) {
+                if (! in_array($methodName, $methods, true)) {
+                    continue;
+                }
+
+                if (! $classReflection->is($interface)) {
+                    continue;
+                }
+
+                $classMethod->attrGroups[] = new AttributeGroup([
+                    new Attribute(new FullyQualified(self::RETURN_TYPE_WILL_CHANGE)),
+                ]);
+
+                $hasChanged = true;
+                break;
+            }
+        }
+
+        if ($hasChanged) {
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function hasReturnTypeWillChangeAttribute(ClassMethod $classMethod): bool
+    {
+        foreach ($classMethod->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if ($attr->name->getLast() === self::RETURN_TYPE_WILL_CHANGE) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Hello there 👋

Here's a proposition to fix this old issue https://github.com/rectorphp/rector/issues/9515

Here's a global explanation of the issue and proposed fix (if necessary):

PHP 8.1 added provisional return types to built-in interfaces (`ArrayAccess`, `Countable`, `Iterator`, `IteratorAggregate` and `Stringable`), triggering deprecation notices on implementations without matching return types.

I created a new `AddReturnTypeWillChangeAttributeRector` rule that automatically detects affected methods, and adds `#[\ReturnTypeWillChange]` to suppress those notices.

The rule is registered in the downgrade-php81 set so it runs automatically for anyone using ->withDowngradeSets(php81: true).

The rule is covered by unit tests, including fixtures for the positive cases (`ArrayAccess`, `Countable`, `Iterator`, `IteratorAggregate` and `Stringable`), and skip cases (method already has a return type, attribute already present).