### PR TITLE
[DowngradePhp80] Handle combine DowngradeMixedTypeDeclarationRector+DowngradeAttributeToAnnotationRector on declare(strict_types=1) inline after open php tag

### DIFF
--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -118,11 +118,13 @@ CODE_SAMPLE
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $key => $attribute) {
                 if ($this->shouldSkipAttribute($attribute)) {
-                    $nextTokenPos = $attrGroup->getEndTokenPos() + 1;
-                    if ($attrGroup->getEndTokenPos() >= 0 && isset($oldTokens[$nextTokenPos]) && ! str_contains(
-                        (string) $oldTokens[$nextTokenPos],
-                        "\n"
-                    )) {
+                    $endTokenPos = $attrGroup->getEndTokenPos();
+                    $nextTokenPos = $endTokenPos + 1;
+                    if (
+                        $endTokenPos >= 0
+                        && isset($oldTokens[$nextTokenPos])
+                        && ! str_contains((string) $oldTokens[$nextTokenPos], "\n")
+                    ) {
                         // add new line
                         $oldTokens[$nextTokenPos]->text = "\n" . $this->resolveIndentation(
                             $node,

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -118,16 +118,17 @@ CODE_SAMPLE
         foreach ($node->attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $key => $attribute) {
                 if ($this->shouldSkipAttribute($attribute)) {
-                    if (isset($oldTokens[$attrGroup->getEndTokenPos() + 1]) && ! str_contains(
-                        (string) $oldTokens[$attrGroup->getEndTokenPos() + 1],
+                    $nextTokenPos = $attrGroup->getEndTokenPos() + 1;
+                    if ($attrGroup->getEndTokenPos() >= 0 && isset($oldTokens[$nextTokenPos]) && ! str_contains(
+                        (string) $oldTokens[$nextTokenPos],
                         "\n"
                     )) {
                         // add new line
-                        $oldTokens[$attrGroup->getEndTokenPos() + 1]->text = "\n" . $this->resolveIndentation(
+                        $oldTokens[$nextTokenPos]->text = "\n" . $this->resolveIndentation(
                             $node,
                             $attrGroup,
                             $attribute
-                        ) . $oldTokens[$attrGroup->getEndTokenPos() + 1]->text;
+                        ) . $oldTokens[$nextTokenPos]->text;
                         $this->isDowngraded = true;
                     }
 

--- a/tests/Issues/IssueDowngradeMixedType/Fixture/do_not_add_newline_before_open_tag.php.inc
+++ b/tests/Issues/IssueDowngradeMixedType/Fixture/do_not_add_newline_before_open_tag.php.inc
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Issues\IssueDowngradeMixedType\Fixture;
+
+class SkipSameLineDeclareStrictType extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function offsetGet($key): mixed
+    {
+    }
+}
+
+?>
+-----
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Issues\IssueDowngradeMixedType\Fixture;
+
+use stdClass;
+use ArrayAccess;
+use Countable;
+use IteratorAggregate;
+use ReturnTypeWillChange;
+
+class SkipSameLineDeclareStrictType extends stdClass implements ArrayAccess, Countable, IteratorAggregate
+{
+    /**
+     * @return mixed
+     */
+    #[ReturnTypeWillChange]
+    public function offsetGet($key)
+    {
+    }
+}
+
+?>

--- a/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
+++ b/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
@@ -5,9 +5,21 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector;
 use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector;
+use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
+use Rector\DowngradePhp80\ValueObject\DowngradeAttributeToAnnotation;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->importNames();
     $rectorConfig->rule(DowngradeTypedPropertyRector::class);
     $rectorConfig->rule(DowngradeMixedTypeDeclarationRector::class);
+
+    $rectorConfig
+        ->ruleWithConfiguration(DowngradeAttributeToAnnotationRector::class, [
+            // Symfony
+            new DowngradeAttributeToAnnotation('Symfony\Contracts\Service\Attribute\Required', 'required'),
+            // Nette
+            new DowngradeAttributeToAnnotation('Nette\DI\Attributes\Inject', 'inject'),
+            // Jetbrains\PhpStorm\Language under nette/utils
+            new DowngradeAttributeToAnnotation('Jetbrains\PhpStorm\Language', 'language'),
+        ]);
 };

--- a/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
+++ b/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
@@ -9,6 +9,11 @@ use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
 use Rector\DowngradePhp80\ValueObject\DowngradeAttributeToAnnotation;
 
 return static function (RectorConfig $rectorConfig): void {
+    /** @var class-string $netteInjectAttribute */
+    $netteInjectAttribute = 'Nette\DI\Attributes\Inject';
+    /** @var class-string $jetbrainsLanguageAttribute */
+    $jetbrainsLanguageAttribute = 'Jetbrains\PhpStorm\Language';
+
     $rectorConfig->importNames();
     $rectorConfig->rule(DowngradeTypedPropertyRector::class);
     $rectorConfig->rule(DowngradeMixedTypeDeclarationRector::class);
@@ -18,8 +23,8 @@ return static function (RectorConfig $rectorConfig): void {
             // Symfony
             new DowngradeAttributeToAnnotation('Symfony\Contracts\Service\Attribute\Required', 'required'),
             // Nette
-            new DowngradeAttributeToAnnotation('Nette\DI\Attributes\Inject', 'inject'),
+            new DowngradeAttributeToAnnotation($netteInjectAttribute, 'inject'),
             // Jetbrains\PhpStorm\Language under nette/utils
-            new DowngradeAttributeToAnnotation('Jetbrains\PhpStorm\Language', 'language'),
+            new DowngradeAttributeToAnnotation($jetbrainsLanguageAttribute, 'language'),
         ]);
 };

--- a/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
+++ b/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-use Jetbrains\PhpStorm\Language;
-use Nette\DI\Attributes\Inject;
 use Rector\Config\RectorConfig;
 use Rector\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector;
 use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
@@ -17,11 +15,6 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig
         ->ruleWithConfiguration(DowngradeAttributeToAnnotationRector::class, [
-            // Symfony
             new DowngradeAttributeToAnnotation('Symfony\Contracts\Service\Attribute\Required', 'required'),
-            // Nette
-            new DowngradeAttributeToAnnotation(Inject::class, 'inject'),
-            // Jetbrains\PhpStorm\Language under nette/utils
-            new DowngradeAttributeToAnnotation(Language::class, 'language'),
         ]);
 };

--- a/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
+++ b/tests/Issues/IssueDowngradeMixedType/config/configured_rule.php
@@ -2,18 +2,15 @@
 
 declare(strict_types=1);
 
+use Jetbrains\PhpStorm\Language;
+use Nette\DI\Attributes\Inject;
 use Rector\Config\RectorConfig;
 use Rector\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector;
-use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector;
 use Rector\DowngradePhp80\Rector\Class_\DowngradeAttributeToAnnotationRector;
+use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector;
 use Rector\DowngradePhp80\ValueObject\DowngradeAttributeToAnnotation;
 
 return static function (RectorConfig $rectorConfig): void {
-    /** @var class-string $netteInjectAttribute */
-    $netteInjectAttribute = 'Nette\DI\Attributes\Inject';
-    /** @var class-string $jetbrainsLanguageAttribute */
-    $jetbrainsLanguageAttribute = 'Jetbrains\PhpStorm\Language';
-
     $rectorConfig->importNames();
     $rectorConfig->rule(DowngradeTypedPropertyRector::class);
     $rectorConfig->rule(DowngradeMixedTypeDeclarationRector::class);
@@ -23,8 +20,8 @@ return static function (RectorConfig $rectorConfig): void {
             // Symfony
             new DowngradeAttributeToAnnotation('Symfony\Contracts\Service\Attribute\Required', 'required'),
             // Nette
-            new DowngradeAttributeToAnnotation($netteInjectAttribute, 'inject'),
+            new DowngradeAttributeToAnnotation(Inject::class, 'inject'),
             // Jetbrains\PhpStorm\Language under nette/utils
-            new DowngradeAttributeToAnnotation($jetbrainsLanguageAttribute, 'language'),
+            new DowngradeAttributeToAnnotation(Language::class, 'language'),
         ]);
 };


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/9759

It cause added new line before inline `<?php declare(strict_types=1);` just after open tag:

```diff
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
+
 <?php declare(strict_types=1);
```