### PR TITLE
Add DowngradeDomNodeChildNodesForeachRector for null $childNodes before PHP 8.0

### DIFF
--- a/config/set/downgrade-php80.php
+++ b/config/set/downgrade-php80.php
@@ -18,6 +18,7 @@ use Rector\DowngradePhp80\Rector\ClassMethod\DowngradeTrailingCommasInParamUseRe
 use Rector\DowngradePhp80\Rector\Enum_\DowngradeEnumToConstantListClassRector;
 use Rector\DowngradePhp80\Rector\Expression\DowngradeMatchToSwitchRector;
 use Rector\DowngradePhp80\Rector\Expression\DowngradeThrowExprRector;
+use Rector\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector;
 use Rector\DowngradePhp80\Rector\FuncCall\DowngradeArrayFilterNullableCallbackRector;
 use Rector\DowngradePhp80\Rector\FuncCall\DowngradeNumberFormatNoFourthArgRector;
 use Rector\DowngradePhp80\Rector\FuncCall\DowngradeStrContainsRector;
@@ -80,6 +81,7 @@ return static function (RectorConfig $rectorConfig): void {
         DowngradeStrEndsWithRector::class,
         DowngradePhpTokenRector::class,
         DowngradeThrowExprRector::class,
+        DowngradeDomNodeChildNodesForeachRector::class,
         DowngradePhp80ResourceReturnToObjectRector::class,
         DowngradeReflectionGetAttributesRector::class,
         DowngradeRecursiveDirectoryIteratorHasChildrenRector::class,

--- a/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/DowngradeDomNodeChildNodesForeachRectorTest.php
+++ b/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/DowngradeDomNodeChildNodesForeachRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeDomNodeChildNodesForeachRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/dom_element_subtype.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/dom_element_subtype.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\Fixture;
+
+class DomElementSubtype
+{
+    public function run(\DOMElement $element)
+    {
+        foreach ($element->childNodes as $childNode) {
+            echo $childNode->nodeValue;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\Fixture;
+
+class DomElementSubtype
+{
+    public function run(\DOMElement $element)
+    {
+        foreach ($element->childNodes ?? [] as $childNode) {
+            echo $childNode->nodeValue;
+        }
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\Fixture;
+
+class SomeClass
+{
+    public function run(\DOMNode $node)
+    {
+        foreach ($node->childNodes as $childNode) {
+            echo $childNode->nodeValue;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\Fixture;
+
+class SomeClass
+{
+    public function run(\DOMNode $node)
+    {
+        foreach ($node->childNodes ?? [] as $childNode) {
+            echo $childNode->nodeValue;
+        }
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/skip_already_coalesced.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/skip_already_coalesced.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\Fixture;
+
+class SkipAlreadyCoalesced
+{
+    public function run(\DOMNode $node)
+    {
+        foreach ($node->childNodes ?? [] as $childNode) {
+            echo $childNode->nodeValue;
+        }
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/skip_non_dom_object.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/skip_non_dom_object.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\Fixture;
+
+use Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\Source\SomeChildAware;
+
+class SkipNonDomObject
+{
+    public function run(SomeChildAware $someChildAware)
+    {
+        foreach ($someChildAware->childNodes as $childNode) {
+            echo $childNode;
+        }
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/skip_other_property.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Fixture/skip_other_property.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\Fixture;
+
+class SkipOtherProperty
+{
+    public function run(\DOMElement $element)
+    {
+        foreach ($element->attributes as $attribute) {
+            echo $attribute->nodeValue;
+        }
+    }
+}

--- a/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Source/SomeChildAware.php
+++ b/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/Source/SomeChildAware.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\Source;
+
+final class SomeChildAware
+{
+    /**
+     * @var mixed[]
+     */
+    public $childNodes = [];
+}

--- a/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DowngradeDomNodeChildNodesForeachRector::class);
+};

--- a/rules/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector.php
+++ b/rules/DowngradePhp80/Rector/Foreach_/DowngradeDomNodeChildNodesForeachRector.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Rector\Foreach_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Stmt\Foreach_;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://github.com/php/php-src/pull/5180 https://bugs.php.net/bug.php?id=79271
+ *
+ * As of PHP 8.0 DOMNode::$childNodes always returns a DOMNodeList. On older
+ * versions it returns null for nodes that cannot have children (e.g. DOMText),
+ * which makes a foreach over it emit "Invalid argument supplied for foreach()".
+ *
+ * @see \Rector\Tests\DowngradePhp80\Rector\Foreach_\DowngradeDomNodeChildNodesForeachRector\DowngradeDomNodeChildNodesForeachRectorTest
+ */
+final class DowngradeDomNodeChildNodesForeachRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add null coalesce to a foreach over DOMNode::$childNodes, as it can be null before PHP 8.0',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+function run(\DOMNode $node)
+{
+    foreach ($node->childNodes as $childNode) {
+        echo $childNode->nodeValue;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+function run(\DOMNode $node)
+{
+    foreach ($node->childNodes ?? [] as $childNode) {
+        echo $childNode->nodeValue;
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Foreach_::class];
+    }
+
+    /**
+     * @param Foreach_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $iteratedExpr = $node->expr;
+        if (! $iteratedExpr instanceof PropertyFetch) {
+            return null;
+        }
+
+        if (! $this->isName($iteratedExpr->name, 'childNodes')) {
+            return null;
+        }
+
+        $callerType = $this->nodeTypeResolver->getType($iteratedExpr->var);
+        if (! $callerType instanceof ObjectType) {
+            return null;
+        }
+
+        if (! $callerType->isInstanceOf('DOMNode')->yes()) {
+            return null;
+        }
+
+        $node->expr = new Coalesce($iteratedExpr, new Array_([]));
+
+        return $node;
+    }
+}


### PR DESCRIPTION
## Why

As of PHP 8.0, `DOMNode::$childNodes` always returns a `DOMNodeList` ([php-src#5180](https://github.com/php/php-src/pull/5180), [bug #79271](https://bugs.php.net/bug.php?id=79271)). On PHP < 8.0 it returns `null` for nodes that cannot have children (e.g. `DOMText`, `DOMDocumentType`).

So code written for 8.0+ that iterates `childNodes` directly:

```php
foreach ($node->childNodes as $childNode) { ... }
```

emits `Warning: Invalid argument supplied for foreach()` once downgraded and run on PHP 7.x. This was hit in real downgraded code (e.g. `nunomaduro/termwind`'s `Node::getChildNodes()`).

## What

New `DowngradeDomNodeChildNodesForeachRector` (PHP 8.0 set) that null-coalesces a `foreach` over `DOMNode::$childNodes`:

```diff
-foreach ($node->childNodes as $childNode) {
+foreach ($node->childNodes ?? [] as $childNode) {
```

It only fires when:
- the iterated expression is a `childNodes` property fetch, and
- the caller's type is `DOMNode` or a subtype (`DOMElement`, etc.).

Scoped to `foreach` on purpose: that is the documented warning and `?? []` is unambiguously safe there. Already-coalesced expressions, other properties (`attributes`), and non-DOM objects are skipped (covered by fixtures).

Registered in `config/set/downgrade-php80.php`. ECS, PHPStan and PHPUnit pass.