### PR TITLE
[DowngradePhp81] Support JsonSerializable in AddReturnTypeWillChangeAttributeRector

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/json_serializable.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector/Fixture/json_serializable.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeJsonSerializable implements \JsonSerializable
+{
+    public function jsonSerialize()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\ClassMethod\AddReturnTypeWillChangeAttributeRector\Fixture;
+
+class SomeJsonSerializable implements \JsonSerializable
+{
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+    }
+}
+
+?>

--- a/rules/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector.php
+++ b/rules/DowngradePhp81/Rector/ClassMethod/AddReturnTypeWillChangeAttributeRector.php
@@ -35,6 +35,7 @@ final class AddReturnTypeWillChangeAttributeRector extends AbstractRector
         'Countable' => ['count'],
         'Iterator' => ['current', 'key', 'next', 'rewind', 'valid'],
         'IteratorAggregate' => ['getIterator'],
+        'JsonSerializable' => ['jsonSerialize'],
         'Stringable' => ['__toString'],
     ];
 


### PR DESCRIPTION
Extending https://github.com/rectorphp/rector-downgrade-php/pull/372, this also adds support for `JsonSerializable` to also solve https://github.com/rectorphp/rector-src/pull/7570#issuecomment-3583247151 .