### PR TITLE
Bump dev dependencies, PHPUnit 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,21 +9,21 @@
     "require-dev": {
         "boundwize/structarmed": "^0.14",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^2.1.33",
+        "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-webmozart-assert": "^2.0",
-        "phpunit/phpunit": "^11.5",
-        "rector/jack": "^0.5.1",
+        "phpunit/phpunit": "^13.2",
+        "rector/jack": "^1.0",
         "rector/rector-src": "dev-main",
-        "rector/swiss-knife": "^2.3",
-        "symplify/easy-coding-standard": "^13.0",
+        "rector/swiss-knife": "^2.4",
+        "symplify/easy-coding-standard": "^13.2",
         "symplify/phpstan-extensions": "^12.0",
-        "symplify/phpstan-rules": "^14.9",
+        "symplify/phpstan-rules": "^14.12",
         "symplify/rule-doc-generator": "^12.2",
         "symplify/vendor-patches": "^11.5",
         "tomasvotruba/class-leak": "^2.1",
         "tomasvotruba/type-coverage": "^2.3",
         "tomasvotruba/unused-public": "^2.2",
-        "tracy/tracy": "^2.11"
+        "tracy/tracy": "^2.12"
     },
     "autoload": {
         "psr-4": {

--- a/rules-tests/DowngradePhp85/Rector/Expression/DowngradeVoidCastRector/DowngradeVoidCastRectorTest.php
+++ b/rules-tests/DowngradePhp85/Rector/Expression/DowngradeVoidCastRector/DowngradeVoidCastRectorTest.php
@@ -12,7 +12,7 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 final class DowngradeVoidCastRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
-    #[RequiresPhp('8.5')]
+    #[RequiresPhp('>= 8.5.0')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/rules-tests/DowngradePhp85/Rector/StmtsAwareInterface/DowngradePipeOperatorRector/DowngradePipeOperatorRectorTest.php
+++ b/rules-tests/DowngradePhp85/Rector/StmtsAwareInterface/DowngradePipeOperatorRector/DowngradePipeOperatorRectorTest.php
@@ -12,7 +12,7 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 final class DowngradePipeOperatorRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]
-    #[RequiresPhp('>= 8.5')]
+    #[RequiresPhp('>= 8.5.0')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
+++ b/rules/DowngradePhp72/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
@@ -211,7 +211,7 @@ CODE_SAMPLE
 
     private function hasParamAlreadyNonTyped(ClassMethod $classMethod): bool
     {
-        return array_all($classMethod->params, fn(Param $param): bool => !$param->type instanceof Node);
+        return array_all($classMethod->params, static fn (Param $param): bool => ! $param->type instanceof Node);
     }
 
     private function isSafeType(ClassReflection $classReflection, ClassMethod $classMethod): bool

--- a/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
+++ b/rules/DowngradePhp73/Rector/List_/DowngradeListReferenceAssignmentRector.php
@@ -130,7 +130,7 @@ CODE_SAMPLE
      * Remove the right-side-most params by reference or empty from `list()`,
      * since they are not needed anymore.
      */
-    private function removeStaleParams(List_ | Array_ $node, int $rightSideRemovableParamsCount): void
+    private function removeStaleParams(List_|Array_ $node, int $rightSideRemovableParamsCount): void
     {
         $nodeItemsCount = count($node->items);
         if ($rightSideRemovableParamsCount > 0) {
@@ -138,7 +138,7 @@ CODE_SAMPLE
         }
     }
 
-    private function shouldSkipAssign(Assign $assign, List_ | Array_ $arrayOrList): bool
+    private function shouldSkipAssign(Assign $assign, List_|Array_ $arrayOrList): bool
     {
         if (! $assign->expr instanceof Variable) {
             return true;
@@ -264,7 +264,7 @@ CODE_SAMPLE
     /**
      * Return the key inside the ArrayItem, if provided, or the position otherwise
      */
-    private function getArrayItemKey(ArrayItem $arrayItem, int | string $position): int | string
+    private function getArrayItemKey(ArrayItem $arrayItem, int|string $position): int|string
     {
         if ($arrayItem->key instanceof String_) {
             return $arrayItem->key->value;
@@ -285,7 +285,7 @@ CODE_SAMPLE
         Variable $assignVariable,
         Variable $exprVariable,
         array $nestedArrayIndexes,
-        string | int $arrayIndex
+        string|int $arrayIndex
     ): Expression {
         $nestedExprVariable = $exprVariable;
         foreach ($nestedArrayIndexes as $nestedArrayIndex) {
@@ -301,7 +301,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<(ArrayItem | null)> $arrayItems
+     * @param array<(ArrayItem|null)> $arrayItems
      * @return ArrayItem[]
      */
     private function getItemsByRef(array $arrayItems, int $condition): array

--- a/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
+++ b/rules/DowngradePhp74/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
@@ -248,7 +248,7 @@ CODE_SAMPLE
         return null;
     }
 
-    private function refactorParam(Param $param, ClassMethod | Function_ $functionLike): void
+    private function refactorParam(Param $param, ClassMethod|Function_ $functionLike): void
     {
         if (! $this->isNullableParam($param, $functionLike)) {
             return;
@@ -260,7 +260,7 @@ CODE_SAMPLE
         $this->hasChanged = true;
     }
 
-    private function decorateWithDocBlock(ClassMethod | Function_ $functionLike, Param $param): void
+    private function decorateWithDocBlock(ClassMethod|Function_ $functionLike, Param $param): void
     {
         if (! $param->type instanceof Node) {
             return;

--- a/rules/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
+++ b/rules/DowngradePhp74/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
@@ -155,7 +155,7 @@ CODE_SAMPLE
 
     private function resolveDifferentAncestorReturnType(
         ClassMethod $classMethod,
-        UnionType | NullableType | Name | Identifier | ComplexType $returnTypeNode
+        UnionType|NullableType|Name|Identifier|ComplexType $returnTypeNode
     ): Type {
         $classReflection = $this->reflectionResolver->resolveClassReflection($classMethod);
         if (! $classReflection instanceof ClassReflection) {
@@ -261,6 +261,6 @@ CODE_SAMPLE
             return false;
         }
 
-        return array_any($parentReturnType->getTypes(), fn(Type $type): bool => $type->equals($returnType));
+        return array_any($parentReturnType->getTypes(), static fn (Type $type): bool => $type->equals($returnType));
     }
 }

--- a/rules/DowngradePhp74/Rector/FuncCall/DowngradeStripTagsCallWithArrayRector.php
+++ b/rules/DowngradePhp74/Rector/FuncCall/DowngradeStripTagsCallWithArrayRector.php
@@ -143,7 +143,7 @@ CODE_SAMPLE
     }
 
     private function createArrayFromString(
-        Array_ | Variable | PropertyFetch | ConstFetch | ClassConstFetch $expr
+        Array_|Variable|PropertyFetch|ConstFetch|ClassConstFetch $expr
     ): Concat {
         $args = [new Arg(new String_('><')), new Arg($expr)];
         $implodeFuncCall = new FuncCall(new Name('implode'), $args);
@@ -153,7 +153,7 @@ CODE_SAMPLE
     }
 
     private function createIsArrayTernaryFromExpression(
-        Variable | PropertyFetch | ConstFetch | ClassConstFetch $expr
+        Variable|PropertyFetch|ConstFetch|ClassConstFetch $expr
     ): Ternary {
         $isArrayFuncCall = new FuncCall(new Name('is_array'), [new Arg($expr)]);
         $nullNotIdentical = new NotIdentical($expr, $this->nodeFactory->createNull());

--- a/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/DowngradePhp74/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -81,7 +81,7 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function shouldSkip(Int_ | Float_ $node, mixed $rawValue): bool
+    private function shouldSkip(Int_|Float_ $node, mixed $rawValue): bool
     {
         if (! is_string($rawValue)) {
             return true;

--- a/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/NamedToUnnamedArgs.php
@@ -70,7 +70,7 @@ final readonly class NamedToUnnamedArgs
      * @return array<int, Arg>
      */
     public function fillFromJumpedNamedArgs(
-        FunctionReflection | MethodReflection | ReflectionFunction $functionLikeReflection,
+        FunctionReflection|MethodReflection|ReflectionFunction $functionLikeReflection,
         array $unnamedArgs,
         array $parameters
     ): array {

--- a/rules/DowngradePhp80/NodeAnalyzer/UnnamedArgumentResolver.php
+++ b/rules/DowngradePhp80/NodeAnalyzer/UnnamedArgumentResolver.php
@@ -26,7 +26,7 @@ final readonly class UnnamedArgumentResolver
      * @return Arg[]
      */
     public function resolveFromReflection(
-        FunctionReflection | MethodReflection $functionLikeReflection,
+        FunctionReflection|MethodReflection $functionLikeReflection,
         array $currentArgs
     ): array {
         $extendedParametersAcceptor = ParametersAcceptorSelector::combineAcceptors(

--- a/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
+++ b/rules/DowngradePhp80/Rector/Class_/DowngradeAttributeToAnnotationRector.php
@@ -207,7 +207,7 @@ CODE_SAMPLE
     }
 
     private function cleanupEmptyAttrGroups(
-        ClassMethod | Property | Class_ | Interface_ | Param | Function_ $node
+        ClassMethod|Property|Class_|Interface_|Param|Function_ $node
     ): void {
         foreach ($node->attrGroups as $key => $attrGroup) {
             if ($attrGroup->attrs !== []) {

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeMatchToSwitchRector.php
@@ -282,7 +282,7 @@ CODE_SAMPLE
      * @return Case_[]
      */
     private function createSwitchCasesFromMatchArms(
-        Echo_ | Expression | Return_ $node,
+        Echo_|Expression|Return_ $node,
         Match_ $match,
         bool $isInsideArrayItem = false
     ): array {
@@ -312,7 +312,7 @@ CODE_SAMPLE
      * @return Stmt[]
      */
     private function createSwitchStmts(
-        Echo_ | Expression | Return_ $node,
+        Echo_|Expression|Return_ $node,
         MatchArm $matchArm,
         bool $isInsideArrayItem
     ): array {

--- a/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
+++ b/rules/DowngradePhp80/Rector/Expression/DowngradeThrowExprRector.php
@@ -150,7 +150,7 @@ CODE_SAMPLE
     /**
      * @return If_|Expression|Stmt[]|null
      */
-    private function refactorAssign(Assign $assign): If_ | Expression | null | array
+    private function refactorAssign(Assign $assign): If_|Expression|null|array
     {
         if (! $this->hasThrowInAssignExpr($assign)) {
             return null;

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeStrContainsRector.php
@@ -62,7 +62,7 @@ CODE_SAMPLE
      * @param FuncCall|BooleanNot $node
      * @return Identical|NotIdentical|null The refactored node.
      */
-    public function refactor(Node $node): Identical | NotIdentical | null
+    public function refactor(Node $node): Identical|NotIdentical|null
     {
         $funcCall = $this->matchStrContainsOrNotStrContains($node);
 
@@ -87,7 +87,7 @@ CODE_SAMPLE
         return new NotIdentical($funcCall, $this->nodeFactory->createFalse());
     }
 
-    private function matchStrContainsOrNotStrContains(FuncCall | BooleanNot $expr): ?FuncCall
+    private function matchStrContainsOrNotStrContains(FuncCall|BooleanNot $expr): ?FuncCall
     {
         $expr = ($expr instanceof BooleanNot) ? $expr->expr : $expr;
         if (! $expr instanceof FuncCall) {

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeNamedArgumentRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeNamedArgumentRector.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
     /**
      * @param Arg[] $args
      */
-    private function removeNamedArguments(MethodCall | StaticCall | New_ | FuncCall $node, array $args): ?Node
+    private function removeNamedArguments(MethodCall|StaticCall|New_|FuncCall $node, array $args): ?Node
     {
         if ($node instanceof New_) {
             $functionLikeReflection = $this->reflectionResolver->resolveMethodReflectionFromNew($node);

--- a/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionClassGetConstantsFilterRector.php
+++ b/rules/DowngradePhp80/Rector/MethodCall/DowngradeReflectionClassGetConstantsFilterRector.php
@@ -299,7 +299,7 @@ CODE_SAMPLE
     /**
      * @return string[]
      */
-    private function resolveClassConstFetchNames(ClassConstFetch | BitwiseOr $value): array
+    private function resolveClassConstFetchNames(ClassConstFetch|BitwiseOr $value): array
     {
         if ($value instanceof ClassConstFetch) {
             $classConstFetchNames = [];

--- a/rules/DowngradePhp80/Reflection/DefaultParameterValueResolver.php
+++ b/rules/DowngradePhp80/Reflection/DefaultParameterValueResolver.php
@@ -20,7 +20,7 @@ use Rector\Exception\ShouldNotHappenException;
 
 final class DefaultParameterValueResolver
 {
-    public function resolveFromParameterReflection(ParameterReflection $parameterReflection): Expr | null
+    public function resolveFromParameterReflection(ParameterReflection $parameterReflection): Expr|null
     {
         $defaultValueType = $parameterReflection->getDefaultValue();
         if (! $defaultValueType instanceof Type) {
@@ -34,7 +34,7 @@ final class DefaultParameterValueResolver
         return $this->resolveValueFromType($defaultValueType);
     }
 
-    private function resolveValueFromType(Type $constantType): ConstFetch | Expr
+    private function resolveValueFromType(Type $constantType): ConstFetch|Expr
     {
         if ($constantType instanceof ConstantBooleanType) {
             return $this->resolveConstantBooleanType($constantType);

--- a/rules/DowngradePhp82/Rector/Class_/DowngradeUnionIntersectionRector.php
+++ b/rules/DowngradePhp82/Rector/Class_/DowngradeUnionIntersectionRector.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\DowngradePhp82\Rector\Class_;
 
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
@@ -137,6 +137,6 @@ CODE_SAMPLE
             return false;
         }
 
-        return array_any($node->types, fn(Identifier|Name|IntersectionType $type): bool => $type instanceof IntersectionType);
+        return array_any($node->types, static fn (Identifier|Name|IntersectionType $type): bool => $type instanceof IntersectionType);
     }
 }


### PR DESCRIPTION
`composer update` + `vendor/bin/jack raise-to-installed`, with PHPUnit taken from 11.5 to 13.

```diff
 "require-dev": {
-    "phpstan/phpstan": "^2.1.33",
+    "phpstan/phpstan": "^2.2",
-    "phpunit/phpunit": "^11.5",
+    "phpunit/phpunit": "^13.2",
-    "rector/jack": "^0.5.1",
+    "rector/jack": "^1.0",
-    "rector/swiss-knife": "^2.3",
+    "rector/swiss-knife": "^2.4",
-    "symplify/easy-coding-standard": "^13.0",
+    "symplify/easy-coding-standard": "^13.2",
-    "symplify/phpstan-rules": "^14.9",
+    "symplify/phpstan-rules": "^14.12",
-    "tracy/tracy": "^2.11"
+    "tracy/tracy": "^2.12"
 }
```

PHPUnit 13 pulls `sebastian/diff` 9, which needs rector-src `04b18f6` or newer (rectorphp/rector-src#8220).

### Two PHP 8.5 tests were running on every PHP version

PHPUnit 13 no longer honours a `RequiresPhp` version that has no comparison operator - it warns and ignores the requirement, so the PHP 8.5 only fixtures got parsed on 8.4 and blew up with `Syntax error, unexpected T_VARIABLE`.

```diff
-    #[RequiresPhp('8.5')]
+    #[RequiresPhp('>= 8.5.0')]
```

```diff
-    #[RequiresPhp('>= 8.5')]
+    #[RequiresPhp('>= 8.5.0')]
```

The second one also needed the patch level - `>= 8.5` alone is reported as incomplete.

### Formatting

The remaining 16 files are `composer fix-cs` output for the newer easy-coding-standard - union type spacing, `static fn`, and `!` spacing:

```diff
-        return array_all($classMethod->params, fn(Param $param): bool => !$param->type instanceof Node);
+        return array_all($classMethod->params, static fn (Param $param): bool => ! $param->type instanceof Node);
```