### PR TITLE
[DowngradePhp84] Add DowngradeExitNamedArgumentRector

### DIFF
--- a/config/set/downgrade-php84.php
+++ b/config/set/downgrade-php84.php
@@ -7,6 +7,7 @@ use Rector\DowngradePhp84\Rector\Expression\DowngradeArrayAllRector;
 use Rector\DowngradePhp84\Rector\Expression\DowngradeArrayAnyRector;
 use Rector\DowngradePhp84\Rector\Expression\DowngradeArrayFindKeyRector;
 use Rector\DowngradePhp84\Rector\Expression\DowngradeArrayFindRector;
+use Rector\DowngradePhp84\Rector\FuncCall\DowngradeExitNamedArgumentRector;
 use Rector\DowngradePhp84\Rector\FuncCall\DowngradeRoundingModeEnumRector;
 use Rector\DowngradePhp84\Rector\MethodCall\DowngradeNewMethodCallWithoutParenthesesRector;
 use Rector\ValueObject\PhpVersion;
@@ -15,6 +16,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(PhpVersion::PHP_83);
     $rectorConfig->rules([
         DowngradeNewMethodCallWithoutParenthesesRector::class,
+        DowngradeExitNamedArgumentRector::class,
         DowngradeRoundingModeEnumRector::class,
         DowngradeArrayAllRector::class,
         DowngradeArrayAnyRector::class,

--- a/rules-tests/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector/DowngradeExitNamedArgumentRectorTest.php
+++ b/rules-tests/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector/DowngradeExitNamedArgumentRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp84\Rector\FuncCall\DowngradeExitNamedArgumentRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeExitNamedArgumentRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\FuncCall\DowngradeExitNamedArgumentRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        exit(status: 1);
+        die(status: 'failure');
+        \exit(status: getStatus());
+        \die(status: getStatus());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\FuncCall\DowngradeExitNamedArgumentRector\Fixture;
+
+class Fixture
+{
+    public function run()
+    {
+        exit(1);
+        die('failure');
+        \exit(getStatus());
+        \die(getStatus());
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector/Fixture/skip_without_named_argument.php.inc
+++ b/rules-tests/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector/Fixture/skip_without_named_argument.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\FuncCall\DowngradeExitNamedArgumentRector\Fixture;
+
+final class SkipWithoutNamedArgument
+{
+    public function run()
+    {
+        exit(1);
+        die('failure');
+        custom(status: 1);
+    }
+}

--- a/rules-tests/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp84\Rector\FuncCall\DowngradeExitNamedArgumentRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DowngradeExitNamedArgumentRector::class);
+};

--- a/rules/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector.php
+++ b/rules/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector.php
@@ -58,7 +58,12 @@ CODE_SAMPLE
             return null;
         }
 
-        $statusArg = $node->getArg('status', 0);
+        $args = $node->getArgs();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $statusArg = $args[0];
         if (! $statusArg instanceof Arg) {
             return null;
         }
@@ -67,7 +72,9 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->args[0]->name = null;
+        $args[0]->name = null;
+        $node->args = $args;
+
         return $node;
     }
 }

--- a/rules/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector.php
+++ b/rules/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector.php
@@ -73,8 +73,6 @@ CODE_SAMPLE
         }
 
         $args[0]->name = null;
-        $node->args = $args;
-
         return $node;
     }
 }

--- a/rules/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector.php
+++ b/rules/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector.php
@@ -72,7 +72,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $args[0]->name = null;
+        $statusArg->name = null;
         return $node;
     }
 }

--- a/rules/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector.php
+++ b/rules/DowngradePhp84/Rector/FuncCall/DowngradeExitNamedArgumentRector.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp84\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Identifier;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/exit-as-function
+ *
+ * @see \Rector\Tests\DowngradePhp84\Rector\FuncCall\DowngradeExitNamedArgumentRector\DowngradeExitNamedArgumentRectorTest
+ */
+final class DowngradeExitNamedArgumentRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove named argument from exit() and die()',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+exit(status: 1);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+exit(1);
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isNames($node, ['exit', 'die'])) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
+        $statusArg = $node->getArg('status', 0);
+        if (! $statusArg instanceof Arg) {
+            return null;
+        }
+
+        if (! $statusArg->name instanceof Identifier) {
+            return null;
+        }
+
+        $node->args[0]->name = null;
+        return $node;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/9844


## Diff 

<!-- Use diff here in Markdown: https://stackoverflow.com/a/40883538/1348344 -->

```diff
-exit(status: 1);
+exit(1);
```

In PHP 8.4, `exit` or `die` can be marked as function call with provide named argument status

https://php.watch/versions/8.4/exit-die-as-functions

On downgrade to php 8.3, it currently doesn't remove the named argument

https://getrector.com/demo/ef539935-7ed2-4cc4-9063-dd07681260ba

On usage, it will create error:

https://3v4l.org/f0f3a#v8.3.33

So, the DowngradePhp84 rule is needed for it.