### PR TITLE
[CI] Fire scoped-rector dispatch on merged PR, not push

### DIFF
--- a/.github/workflows/dispatch_build_scoped_rector.yaml
+++ b/.github/workflows/dispatch_build_scoped_rector.yaml
@@ -20,8 +20,8 @@ jobs:
 
         steps:
             -
-                name: "Wait 20 seconds after merge"
-                run: sleep 20
+                name: "Wait 10 seconds after merge"
+                run: sleep 10
 
             -
                 name: "Check whether rector-src main is a release tag commit"

--- a/.github/workflows/dispatch_build_scoped_rector.yaml
+++ b/.github/workflows/dispatch_build_scoped_rector.yaml
@@ -2,23 +2,25 @@
 # with the freshly merged rector-downgrade-php main
 name: Dispatch Build Scoped Rector
 
+# pull_request_target fires on merge even for fork PRs and, unlike "push",
+# is not suppressed when the merge commit is pushed with GITHUB_TOKEN
 on:
-    push:
-        branches:
-            - main
+    pull_request_target:
+        types:
+            - closed
     workflow_dispatch: null
 
 jobs:
     dispatch_build_scoped_rector:
-        # only for this repository, not forks
-        if: github.repository == 'rectorphp/rector-downgrade-php'
+        # only for this repository, not forks; and only on a merged PR (not a plain close)
+        if: github.repository == 'rectorphp/rector-downgrade-php' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true)
 
         runs-on: ubuntu-latest
         timeout-minutes: 10
 
         steps:
             -
-                name: "Wait 20 seconds after push"
+                name: "Wait 20 seconds after merge"
                 run: sleep 20
 
             -


### PR DESCRIPTION
## Problem

Merging a PR into this package's main should rebuild `rectorphp/rector` via rector-src `build_scoped_rector.yaml`. The dispatcher triggered on `push: main`, but a merge commit pushed with `GITHUB_TOKEN` does **not** trigger `push` workflows (GitHub loop-prevention), so the dispatch can silently never run.

Observed live on rector-phpunit#770: the merge commit fired zero Actions and the scoped rebuild never happened. Same fix as rectorphp/rector-phpunit#774.

## Fix

```diff
 on:
-    push:
-        branches:
-            - main
+    pull_request_target:
+        types:
+            - closed
     workflow_dispatch: null
```

- `pull_request_target` (not `pull_request`) so the job runs in base-repo context **with secrets** — fork PRs otherwise get an empty `ACCESS_TOKEN`.
- `merged == true` guard so a plain close does not dispatch.
- No PR code is checked out (only `gh workflow run`), so `pull_request_target` carries no injection risk here.

`workflow_dispatch` retained for manual runs.