### PR TITLE
Ignore false-positive cheaper-guard order in DowngradeSubstrFalsyRector

### DIFF
--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeSubstrFalsyRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeSubstrFalsyRector.php
@@ -178,6 +178,7 @@ final class DowngradeSubstrFalsyRector extends AbstractRector
             }
         }
 
+        // @phpstan-ignore rector.rectorCheaperGuardsFirst (cannot hoist above the CallLike block, which marks IS_FALSY_UNCASTABLE on non-substr nodes)
         if (! $this->isName($node, 'substr')) {
             return null;
         }


### PR DESCRIPTION
symplify/phpstan-rules 14.13.0 adds `RectorCheaperGuardsFirstRule`, which flags a cheap guard placed after an expensive analysis call.

In `DowngradeSubstrFalsyRector` the `isName($node, 'substr')` guard is flagged, but it **cannot** be hoisted: the preceding `CallLike` block marks `IS_FALSY_UNCASTABLE` on the arguments of non-substr call nodes, and that side effect is what lets nested `substr()` in falsy-tolerant parameter positions be skipped later. Moving the guard up would make non-substr nodes bail before the marking runs, wrongly rewriting those nested calls (covered by `skip_as_falsy_arg` and `skip_new_arg_falsy` fixtures).

Adds a narrow inline `@phpstan-ignore` with the reason. Genuine false positive for this method.