### PR TITLE
Drop cheaper-guard ignore, rely on fixed rule (14.13.1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "rector/swiss-knife": "^2.4",
         "symplify/easy-coding-standard": "^13.2",
         "symplify/phpstan-extensions": "^12.0",
-        "symplify/phpstan-rules": "^14.12",
+        "symplify/phpstan-rules": "^14.13.1",
         "symplify/rule-doc-generator": "^12.2",
         "tomasvotruba/class-leak": "^2.1",
         "tomasvotruba/type-coverage": "^2.3",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -111,8 +111,3 @@ parameters:
 
         # local attribute key
         - '#Parameter \#2 \$attributeKey of static method Rector\\PhpParser\\NodeTraverser\\SimpleNodeTraverser\:\:decorateWithAttributeValue\(\) expects#'
-
-        # guard cannot hoist above the CallLike block that marks IS_FALSY_UNCASTABLE on non-substr nodes
-        -
-            identifier: rector.rectorCheaperGuardsFirst
-            path: rules/DowngradePhp80/Rector/FuncCall/DowngradeSubstrFalsyRector.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -111,3 +111,8 @@ parameters:
 
         # local attribute key
         - '#Parameter \#2 \$attributeKey of static method Rector\\PhpParser\\NodeTraverser\\SimpleNodeTraverser\:\:decorateWithAttributeValue\(\) expects#'
+
+        # guard cannot hoist above the CallLike block that marks IS_FALSY_UNCASTABLE on non-substr nodes
+        -
+            identifier: rector.rectorCheaperGuardsFirst
+            path: rules/DowngradePhp80/Rector/FuncCall/DowngradeSubstrFalsyRector.php

--- a/rules/DowngradePhp80/Rector/FuncCall/DowngradeSubstrFalsyRector.php
+++ b/rules/DowngradePhp80/Rector/FuncCall/DowngradeSubstrFalsyRector.php
@@ -178,7 +178,6 @@ final class DowngradeSubstrFalsyRector extends AbstractRector
             }
         }
 
-        // @phpstan-ignore rector.rectorCheaperGuardsFirst (cannot hoist above the CallLike block, which marks IS_FALSY_UNCASTABLE on non-substr nodes)
         if (! $this->isName($node, 'substr')) {
             return null;
         }


### PR DESCRIPTION
The false positive is now fixed at the source in symplify/phpstan-rules 14.13.1 (symplify/phpstan-rules#281): the rule no longer flags a guard when the anchor has side effects. The inline @phpstan-ignore added in #391 is removed entirely (no neon ignore needed), and the constraint is bumped to ^14.13.1. PHPStan green.