### PR TITLE
Add DowngradeDeprecatedAttributeRector

### DIFF
--- a/config/set/downgrade-php84.php
+++ b/config/set/downgrade-php84.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\DowngradePhp84\Rector\Expression\DowngradeArrayAllRector;
 use Rector\DowngradePhp84\Rector\Expression\DowngradeArrayAnyRector;
 use Rector\DowngradePhp84\Rector\Expression\DowngradeArrayFindKeyRector;
+use Rector\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector;
 use Rector\DowngradePhp84\Rector\Expression\DowngradeArrayFindRector;
 use Rector\DowngradePhp84\Rector\FuncCall\DowngradeExitNamedArgumentRector;
 use Rector\DowngradePhp84\Rector\FuncCall\DowngradeRoundingModeEnumRector;
@@ -22,5 +23,6 @@ return static function (RectorConfig $rectorConfig): void {
         DowngradeArrayAnyRector::class,
         DowngradeArrayFindRector::class,
         DowngradeArrayFindKeyRector::class,
+        DowngradeDeprecatedAttributeRector::class,
     ]);
 };

--- a/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/DowngradeDeprecatedAttributeRectorTest.php
+++ b/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/DowngradeDeprecatedAttributeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class DowngradeDeprecatedAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/class_const.php.inc
+++ b/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/class_const.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\Fixture;
+
+class ClassConstDeprecated
+{
+    #[\Deprecated('use NEW_VALUE instead')]
+    public const OLD_VALUE = 1;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\Fixture;
+
+class ClassConstDeprecated
+{
+    /**
+     * @deprecated use NEW_VALUE instead
+     */
+    public const OLD_VALUE = 1;
+}
+
+?>

--- a/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/heredoc_message.php.inc
+++ b/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/heredoc_message.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\Fixture;
+
+class HeredocMessage
+{
+    #[\Deprecated(message: <<<'TXT'
+    Niche mechanism, no longer applied. Let Rector handle cache on its own.
+     If custom invalidation is needed, handle it in CI.
+    TXT)]
+    public function someMethod(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\Fixture;
+
+class HeredocMessage
+{
+    /**
+     * @deprecated Niche mechanism, no longer applied. Let Rector handle cache on its own. If custom invalidation is needed, handle it in CI.
+     */
+    public function someMethod(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/method_message_and_since.php.inc
+++ b/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/method_message_and_since.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\Fixture;
+
+class MethodMessageAndSince
+{
+    #[\Deprecated(message: 'use someOtherMethod() instead', since: '1.5')]
+    public function someMethod(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\Fixture;
+
+class MethodMessageAndSince
+{
+    /**
+     * @deprecated 1.5 use someOtherMethod() instead
+     */
+    public function someMethod(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/no_args.php.inc
+++ b/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/no_args.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\Fixture;
+
+class NoArgs
+{
+    #[\Deprecated]
+    public function someMethod(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\Fixture;
+
+class NoArgs
+{
+    /**
+     * @deprecated
+     */
+    public function someMethod(): void
+    {
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/skip_other_attribute.php.inc
+++ b/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/Fixture/skip_other_attribute.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\Fixture;
+
+class SkipOtherAttribute
+{
+    #[\Override]
+    public function someMethod(): void
+    {
+    }
+}

--- a/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/config/configured_rule.php
+++ b/rules-tests/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(DowngradeDeprecatedAttributeRector::class);
+};

--- a/rules/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector.php
+++ b/rules/DowngradePhp84/Rector/ClassMethod/DowngradeDeprecatedAttributeRector.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp84\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\EnumCase;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://wiki.php.net/rfc/deprecated_attribute
+ *
+ * @see \Rector\Tests\DowngradePhp84\Rector\ClassMethod\DowngradeDeprecatedAttributeRector\DowngradeDeprecatedAttributeRectorTest
+ */
+final class DowngradeDeprecatedAttributeRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Downgrade #[\Deprecated] attribute to @deprecated annotation', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    #[\Deprecated(message: 'use SomeOtherMethod() instead', since: '1.5')]
+    public function someMethod(): void
+    {
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    /**
+     * @deprecated 1.5 use SomeOtherMethod() instead
+     */
+    public function someMethod(): void
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class, ClassConst::class, EnumCase::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_|ClassConst|EnumCase $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->attrGroups === []) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->attrGroups as $attrGroupKey => $attrGroup) {
+            foreach ($attrGroup->attrs as $attrKey => $attribute) {
+                if (! $this->isName($attribute->name, 'Deprecated')) {
+                    continue;
+                }
+
+                $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+                $phpDocInfo->addPhpDocTagNode(
+                    new PhpDocTagNode('@deprecated', new GenericTagValueNode($this->createTagValue($attribute)))
+                );
+
+                unset($attrGroup->attrs[$attrKey]);
+                $hasChanged = true;
+            }
+
+            if ($attrGroup->attrs === []) {
+                unset($node->attrGroups[$attrGroupKey]);
+            }
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+
+    private function createTagValue(Attribute $attribute): string
+    {
+        $message = null;
+        $since = null;
+
+        foreach ($attribute->args as $position => $arg) {
+            $value = $this->valueResolver->getValue($arg->value);
+            if (! is_string($value)) {
+                continue;
+            }
+
+            $name = $arg instanceof Arg && $arg->name instanceof Identifier
+                ? $arg->name->toString()
+                : ($position === 0 ? 'message' : 'since');
+
+            if ($name === 'since') {
+                $since = $value;
+            } elseif ($name === 'message') {
+                $message = $value;
+            }
+        }
+
+        $parts = array_filter([$since, $message], static fn (?string $part): bool => $part !== null && $part !== '');
+
+        return implode(' ', array_map(static fn (string $part): string => (string) preg_replace(
+            '#\s+#',
+            ' ',
+            trim($part)
+        ), $parts));
+    }
+}


### PR DESCRIPTION
New downgrade rule for PHP 8.4 `#[\Deprecated]` attribute.

Flips the attribute to a `@deprecated` annotation, docblock-way:

```php
 #[\Deprecated(message: 'use someOtherMethod() instead', since: '1.5')]
 public function someMethod(): void
 {
 }
```

into:

```php
 /**
  * @deprecated 1.5 use someOtherMethod() instead
  */
 public function someMethod(): void
 {
 }
```

- Handles methods, functions, class constants and enum cases.
- Reads `message` and `since` args (named or positional); multiline heredoc messages are collapsed to a single line.
- Registered in the `downgrade-php84.php` set.
