### PR TITLE
Handle getProperties()/getMethods() loop in DowngradeSetAccessibleReflectionPropertyRector

### DIFF
--- a/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/on_get_methods.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/on_get_methods.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\StmtsAwareInterface\DowngradeSetAccessibleReflectionPropertyRector\Fixture;
+
+class OnGetMethods
+{
+    public function run($object)
+    {
+        $reflectionClass = new \ReflectionClass($object);
+        foreach ($reflectionClass->getMethods() as $reflectionMethod) {
+            $reflectionMethod->invoke($object);
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\StmtsAwareInterface\DowngradeSetAccessibleReflectionPropertyRector\Fixture;
+
+class OnGetMethods
+{
+    public function run($object)
+    {
+        $reflectionClass = new \ReflectionClass($object);
+        foreach ($reflectionClass->getMethods() as $reflectionMethod) {
+            if (PHP_VERSION_ID < 80100) {
+                $reflectionMethod->setAccessible(true);
+            }
+            $reflectionMethod->invoke($object);
+        }
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/on_get_properties.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/on_get_properties.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\StmtsAwareInterface\DowngradeSetAccessibleReflectionPropertyRector\Fixture;
+
+class OnGetProperties
+{
+    public function run($object)
+    {
+        $reflectionObject = new \ReflectionObject($object);
+        foreach ($reflectionObject->getProperties() as $reflectionProperty) {
+            echo $reflectionProperty->getValue($object);
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\StmtsAwareInterface\DowngradeSetAccessibleReflectionPropertyRector\Fixture;
+
+class OnGetProperties
+{
+    public function run($object)
+    {
+        $reflectionObject = new \ReflectionObject($object);
+        foreach ($reflectionObject->getProperties() as $reflectionProperty) {
+            if (PHP_VERSION_ID < 80100) {
+                $reflectionProperty->setAccessible(true);
+            }
+            echo $reflectionProperty->getValue($object);
+        }
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/skip_already_accessible_in_foreach.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/skip_already_accessible_in_foreach.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\StmtsAwareInterface\DowngradeSetAccessibleReflectionPropertyRector\Fixture;
+
+class SkipAlreadyAccessibleInForeach
+{
+    public function run($object)
+    {
+        $reflectionObject = new \ReflectionObject($object);
+        foreach ($reflectionObject->getProperties() as $reflectionProperty) {
+            if (PHP_VERSION_ID < 80100) {
+                $reflectionProperty->setAccessible(true);
+            }
+            echo $reflectionProperty->getValue($object);
+        }
+    }
+}

--- a/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/skip_non_reflection_get_properties.php.inc
+++ b/rules-tests/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector/Fixture/skip_non_reflection_get_properties.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp81\Rector\StmtsAwareInterface\DowngradeSetAccessibleReflectionPropertyRector\Fixture;
+
+class SomeCollection
+{
+    public function getProperties(): array
+    {
+        return [];
+    }
+}
+
+class SkipNonReflectionGetProperties
+{
+    public function run()
+    {
+        $collection = new SomeCollection();
+        foreach ($collection->getProperties() as $property) {
+            echo $property;
+        }
+    }
+}

--- a/rules/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector.php
+++ b/rules/DowngradePhp81/Rector/StmtsAwareInterface/DowngradeSetAccessibleReflectionPropertyRector.php
@@ -16,8 +16,10 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
+use PHPStan\Type\ObjectType;
 use Rector\Naming\Naming\VariableNaming;
 use Rector\PhpParser\Enum\NodeGroup;
 use Rector\PHPStan\ScopeFetcher;
@@ -72,6 +74,38 @@ class SomeClass
 CODE_SAMPLE
                 ),
 
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($object)
+    {
+        $reflectionObject = new ReflectionObject($object);
+        foreach ($reflectionObject->getProperties() as $reflectionProperty) {
+            echo $reflectionProperty->getValue($object);
+        }
+    }
+}
+CODE_SAMPLE
+
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($object)
+    {
+        $reflectionObject = new ReflectionObject($object);
+        foreach ($reflectionObject->getProperties() as $reflectionProperty) {
+            if (PHP_VERSION_ID < 80100) {
+                $reflectionProperty->setAccessible(true);
+            }
+            echo $reflectionProperty->getValue($object);
+        }
+    }
+}
+CODE_SAMPLE
+                ),
+
             ]
         );
     }
@@ -96,6 +130,14 @@ CODE_SAMPLE
         $hasChanged = false;
 
         foreach ($node->stmts as $key => $stmt) {
+            if ($stmt instanceof Foreach_) {
+                if ($this->refactorForeach($stmt)) {
+                    $hasChanged = true;
+                }
+
+                continue;
+            }
+
             if (! $stmt instanceof Expression && ! $stmt instanceof Return_) {
                 continue;
             }
@@ -156,6 +198,45 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function refactorForeach(Foreach_ $foreach): bool
+    {
+        if (! $foreach->valueVar instanceof Variable) {
+            return false;
+        }
+
+        if (! $this->isReflectionMembersCall($foreach->expr)) {
+            return false;
+        }
+
+        $firstStmt = $foreach->stmts[0] ?? null;
+        if ($this->isSetAccessibleMethodCall($firstStmt) || $this->isSetAccessibleIfMethodCall($firstStmt)) {
+            return false;
+        }
+
+        array_unshift($foreach->stmts, $this->createSetAccessibleExpression($foreach->valueVar));
+
+        return true;
+    }
+
+    private function isReflectionMembersCall(Expr $expr): bool
+    {
+        if (! $expr instanceof MethodCall) {
+            return false;
+        }
+
+        if (! $this->isNames($expr->name, ['getProperties', 'getMethods'])) {
+            return false;
+        }
+
+        $callerType = $this->nodeTypeResolver->getType($expr->var);
+        if (! $callerType instanceof ObjectType) {
+            return false;
+        }
+
+        return $callerType->isInstanceOf('ReflectionClass')
+            ->yes();
     }
 
     private function createSetAccessibleExpression(Expr $expr): If_


### PR DESCRIPTION
Fixes rectorphp/rector#9878.

## Problem

On a downgraded PHP 7.4 build, `php vendor/bin/rector composer-based` throws:

> Cannot access non-public member Rector\PHPUnit\ValueObject\AnnotationWithValueToAttribute::$annotationName

`DowngradeSetAccessibleReflectionPropertyRector` only inserts the guarded `setAccessible(true)` when a `ReflectionProperty`/`ReflectionMethod` is built with `new`. When the property comes from a `ReflectionClass::getProperties()` (or `getMethods()`) loop - as in `ComposerBasedCommand::printConfigurationValue()` - the rule never fired, so the 7.4 build read a non-public member without `setAccessible()`.

## Change

Detect a `foreach` iterating a `ReflectionClass` (incl. `ReflectionObject`, `ReflectionEnum`) `getProperties()`/`getMethods()` call, and prepend the guarded `setAccessible(true)` to the loop body:

```php
foreach ($reflectionObject->getProperties() as $reflectionProperty) {
    if (PHP_VERSION_ID < 80100) {
        $reflectionProperty->setAccessible(true);
    }
    echo $reflectionProperty->getValue($object);
}
```

The caller type is checked against `ReflectionClass`, so unrelated `getProperties()` methods are left untouched. Idempotent - skips when the guard is already present.

## Tests

Added fixtures: `on_get_properties`, `on_get_methods`, `skip_non_reflection_get_properties`, `skip_already_accessible_in_foreach`. Full rule test green.

https://claude.ai/code/session_01HDxKQQjvqdXnmdvetn4t5d